### PR TITLE
fix(autotask): retry once on 401 with a fresh zone lookup

### DIFF
--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -6,7 +6,7 @@
 //
 // Zero new runtime deps — Node 18+ built-in `fetch` only.
 
-import { resolveAutotaskApiUrl } from '../utils/config';
+import { resolveAutotaskApiUrl, invalidateZoneUrlCache } from '../utils/config';
 import { Logger } from '../utils/logger';
 
 export interface QueryFilter {
@@ -145,7 +145,7 @@ export class AutotaskHttpClient {
    * (resolved against the zone base URL) or an absolute URL (used by
    * pageDetails.nextPageUrl pagination).
    */
-  private async request<T>(method: string, path: string, body?: any): Promise<T> {
+  private async request<T>(method: string, path: string, body?: any, isZoneRetry = false): Promise<T> {
     const url = path.startsWith('http') ? path : `${await this.baseUrl()}${path.startsWith('/') ? '' : '/'}${path}`;
 
     this.logger.debug(`Autotask HTTP ${method} ${url}`);
@@ -173,6 +173,20 @@ export class AutotaskHttpClient {
     const text = await response.text().catch(() => '');
 
     if (!response.ok) {
+      // A 401 against a relative (zone-resolved) path — as opposed to an
+      // absolute pageDetails.nextPageUrl, which is already baked to a host
+      // we can't safely rewrite — most often means our cached zone URL is
+      // stale (e.g. a data-center migration moved this tenant to a new
+      // zone after we cached the old one). Drop the cache and retry once
+      // against a freshly-resolved zone before giving up.
+      if (response.status === 401 && !isZoneRetry && !path.startsWith('http')) {
+        this.logger.debug(
+          `Autotask ${method} ${path} returned 401 — invalidating cached zone for ${this.username} and retrying once`
+        );
+        this.resolvedBaseUrl = null;
+        invalidateZoneUrlCache(this.username);
+        return this.request<T>(method, path, body, true);
+      }
       let detail = text.slice(0, 1000);
       try {
         const parsed = JSON.parse(text);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -186,6 +186,18 @@ export function _resetZoneUrlCache(): void {
 }
 
 /**
+ * Drop the cached zone URL for a single username. Call this when a real
+ * Autotask API request (not the zoneInformation lookup itself) comes back
+ * 401 — the cache has no TTL, so a data-center migration that moves a
+ * tenant to a new zone after we've already cached the old one would
+ * otherwise pin that tenant to the wrong host for the rest of the process
+ * lifetime. The next resolveAutotaskApiUrl call re-resolves from scratch.
+ */
+export function invalidateZoneUrlCache(username: string): void {
+  zoneUrlCache.delete(username.toLowerCase());
+}
+
+/**
  * Minimal logger shape accepted by resolveAutotaskApiUrl so we don't
  * have a hard dep on the Logger class (keeps this pre-auth bootstrap simple).
  */

--- a/tests/zone-401-retry.test.ts
+++ b/tests/zone-401-retry.test.ts
@@ -1,0 +1,168 @@
+// Regression tests: a stale cached zone URL (e.g. after a Kaseya data-centre
+// migration moves a tenant to a new zone) must not permanently 401 a tenant
+// for the rest of the process lifetime. AutotaskHttpClient.request() retries
+// once against a freshly-resolved zone on 401, and resolveAutotaskApiUrl's
+// cache supports targeted per-username invalidation.
+
+import { AutotaskHttpClient } from '../src/services/autotask-http';
+import { _resetZoneUrlCache, invalidateZoneUrlCache, resolveAutotaskApiUrl } from '../src/utils/config';
+
+const logger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+};
+
+const makeClient = (apiUrl = 'https://webservices18.autotask.net/ATServicesRest/') =>
+  new AutotaskHttpClient('user@example.com', 'secret', 'integration-code', apiUrl, logger as any);
+
+beforeEach(() => {
+  _resetZoneUrlCache();
+  Object.values(logger).forEach((m: any) => m.mockReset?.());
+});
+
+describe('invalidateZoneUrlCache', () => {
+  it('removes only the named username, leaving other cached zones intact', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ url: 'https://webservices2.autotask.net/atservicesrest/' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ url: 'https://webservices7.autotask.net/atservicesrest/' }) });
+
+    await resolveAutotaskApiUrl('alice@example.com', undefined, logger, fetchMock as any);
+    await resolveAutotaskApiUrl('bob@example.com', undefined, logger, fetchMock as any);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    invalidateZoneUrlCache('ALICE@example.com'); // case-insensitive key match
+
+    // Alice re-resolves (cache miss); Bob still hits the cache (no new fetch call for Bob).
+    const freshFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ url: 'https://webservices31.autotask.net/atservicesrest/' }),
+    });
+    const alice = await resolveAutotaskApiUrl('alice@example.com', undefined, logger, freshFetch as any);
+    expect(alice).toBe('https://webservices31.autotask.net/atservicesrest/');
+    expect(freshFetch).toHaveBeenCalledTimes(1);
+
+    const bob = await resolveAutotaskApiUrl('bob@example.com', undefined, logger, freshFetch as any);
+    expect(bob).toBe('https://webservices7.autotask.net/atservicesrest/');
+    // Bob was a cache hit, so freshFetch was never called for Bob.
+    expect(freshFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AutotaskHttpClient 401 retry (stale zone cache)', () => {
+  it('invalidates the cached base URL and retries once against a fresh zone on 401', async () => {
+    const client = makeClient();
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockImplementation((urlArg: any) => {
+      const url = String(urlArg);
+      if (url.startsWith('https://webservices18')) {
+        // Stale zone: rejects with 401.
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ errors: ['Authentication failed'] }),
+        } as any);
+      }
+      throw new Error(`unexpected host in test: ${url}`);
+    });
+
+    try {
+      await expect(client.get('Companies', 123)).rejects.toThrow(/HTTP 401/);
+      // First attempt + retry attempt, both against the same (only-configured) zone,
+      // proving the retry actually fired rather than the first 401 propagating straight up.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('succeeds after invalidation once a fresh zone lookup returns a working host', async () => {
+    // No explicit apiUrl: forces auto-detection through resolveAutotaskApiUrl,
+    // so we can prove the retry re-resolves via a fresh zoneInformation call.
+    // (Not routed through makeClient()'s default parameter — passing `undefined`
+    // explicitly would still trigger its default value, defeating the point.)
+    const client = new AutotaskHttpClient('user@example.com', 'secret', 'integration-code', undefined, logger as any);
+    let zoneCalls = 0;
+
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockImplementation((urlArg: any) => {
+      const url = String(urlArg);
+      if (url.includes('zoneInformation')) {
+        zoneCalls += 1;
+        // First lookup returns the stale (pre-migration) zone; second returns Sydney.
+        const zoneUrl =
+          zoneCalls === 1
+            ? 'https://webservices18.autotask.net/atservicesrest/'
+            : 'https://webservices31.autotask.net/atservicesrest/';
+        return Promise.resolve({ ok: true, status: 200, json: async () => ({ url: zoneUrl }) } as any);
+      }
+      if (url.startsWith('https://webservices18')) {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ errors: ['Authentication failed'] }),
+        } as any);
+      }
+      if (url.startsWith('https://webservices31')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ item: { id: 123, companyName: 'Acme' } }),
+        } as any);
+      }
+      throw new Error(`unexpected host in test: ${url}`);
+    });
+
+    try {
+      const result = await client.get<{ id: number; companyName: string }>('Companies', 123);
+      expect(result).toEqual({ id: 123, companyName: 'Acme' });
+      expect(zoneCalls).toBe(2);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('does not retry a second time (avoids infinite loop) if the fresh zone also 401s', async () => {
+    const client = makeClient();
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      text: async () => JSON.stringify({ errors: ['Authentication failed'] }),
+    } as any);
+
+    try {
+      await expect(client.get('Companies', 123)).rejects.toThrow(/HTTP 401/);
+      expect(fetchMock).toHaveBeenCalledTimes(2); // original + exactly one retry, then throws
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('does not retry a 401 reached via rawRequest (already resolved to an absolute zone URL)', async () => {
+    // rawRequest() resolves `${base}${path}` into an absolute URL itself before
+    // calling request(), so request() sees path.startsWith('http') === true and
+    // skips the retry — rewriting an already zone-baked absolute URL wouldn't
+    // pick up a freshly-invalidated zone anyway.
+    const client = makeClient();
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      text: async () => JSON.stringify({ errors: ['Authentication failed'] }),
+    } as any);
+
+    try {
+      await expect(
+        client.rawRequest('GET', '/Companies/query/next?paging=abc')
+      ).rejects.toThrow(/HTTP 401/);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // no retry
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `resolveAutotaskApiUrl()`'s zone cache (`zoneUrlCache` in `src/utils/config.ts`) has no TTL and is never invalidated — once a tenant's zone is resolved it's pinned for the life of the process.
- When Kaseya migrates a tenant's Autotask instance to a different data-centre zone (per their published zone-move guidance), a long-lived process keeps sending requests to the pre-migration zone URL and receives 401s, while the tenant's other traffic reaches the new zone normally.
- `AutotaskHttpClient.request()` now invalidates the cached zone (instance-level `resolvedBaseUrl` + the shared `zoneUrlCache` entry) and retries once against a freshly-resolved zone whenever a real API request comes back 401. Doesn't apply to `rawRequest()`'s already zone-baked absolute URLs — there's no cache to rewrite in that path.

## Test plan
- [x] `npx jest tests/zone-401-retry.test.ts` — 5 new tests: targeted per-username cache invalidation, successful retry-after-401 with a fresh zone, no infinite retry loop, no retry on the absolute-URL (`rawRequest`) path.
- [x] `npx jest tests/config-zone-detection.test.ts tests/contact-update-zone18.test.ts` — no regressions.
- [x] Full suite: 145/145 tests pass. 6 pre-existing suite failures are unrelated (`Cannot find module '@modelcontextprotocol/server'` — missing dep in this environment, present before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Q2RdHhdrqMuRoGJSGD9s