### PR TITLE
fix(mapping): share warmed cache per tenant and bound warm-up waits

### DIFF
--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -111,9 +111,14 @@ export class AutotaskToolHandler {
       // Per-toolHandler MappingService instance. In gateway mode this
       // toolHandler is created per-request (see McpServer.buildPerRequestHandlers),
       // so each tenant gets a MappingService bound to its own AutotaskService —
-      // company/resource caches cannot leak across tenants.
+      // company/resource caches cannot leak across tenants. The tenantKey
+      // lets same-tenant instances share warmed cache DATA across requests
+      // (keyed by credential, so isolation still holds) — without it, every
+      // request re-walked the tenant's full company list, stalling responses
+      // past the gateway timeout on large tenants.
       this.mappingService = await MappingService.create(this.autotaskService, this.logger, {
         lazyLoading: this.lazyLoading,
+        tenantKey: this.autotaskService.getTenantKey() ?? undefined,
       });
     }
     return this.mappingService;

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -69,6 +69,17 @@ export class AutotaskRateLimitError extends Error {
   }
 }
 
+/**
+ * Per-request ceiling for a single Autotask REST call. Distant zones (e.g.
+ * an Azure US region talking to the Sydney zone) add meaningful RTT, and
+ * heavyweight requests (500-row query pages, entityInformation) can
+ * legitimately run long — cutting them off early just wastes the work.
+ * Callers above us (gateway, MCP client) enforce their own end-to-end
+ * budgets, so this is a backstop against a truly hung connection, not the
+ * primary timeout.
+ */
+const REQUEST_TIMEOUT_MS = 60_000;
+
 // Default backoff when Autotask doesn't send a parseable Retry-After header.
 // One minute is conservative: their thresholds reset on a rolling hour window,
 // so waiting longer than a minute is rarely useful, and waiting less risks
@@ -108,7 +119,7 @@ function assertSafeRelativePath(path: string): void {
  * All public methods:
  * - use the zone-resolved base URL (cached per-username via resolveAutotaskApiUrl)
  * - send the standard ApiIntegrationcode/UserName/Secret auth headers
- * - apply a 30-second timeout via AbortSignal.timeout
+ * - apply a 60-second timeout via AbortSignal.timeout (REQUEST_TIMEOUT_MS)
  * - throw an Error on non-2xx with the API error array when available
  */
 export class AutotaskHttpClient {
@@ -155,7 +166,7 @@ export class AutotaskHttpClient {
       const init: RequestInit = {
         method,
         headers: this.headers(),
-        signal: AbortSignal.timeout(30_000),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       };
       if (body !== undefined) {
         init.body = JSON.stringify(body);

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -97,6 +97,16 @@ export class AutotaskService {
   }
 
   /**
+   * Stable identity of the tenant these credentials belong to (lowercased
+   * API username), used to key per-tenant caches that outlive a single
+   * request. Null when credentials aren't configured.
+   */
+  getTenantKey(): string | null {
+    const username = this.config.autotask.username;
+    return username ? username.toLowerCase() : null;
+  }
+
+  /**
    * Initialize the Autotask HTTP client with credentials.
    *
    * We only validate credentials here — the zone-resolved URL is fetched

--- a/src/utils/mapping.service.ts
+++ b/src/utils/mapping.service.ts
@@ -21,6 +21,50 @@ export interface MappingResult {
   found: boolean;
 }
 
+/**
+ * How long a request is allowed to block on cache warm-up before proceeding
+ * with fallback (per-ID) lookups. The full pre-warm walks EVERY company in
+ * the tenant (thousands of records for large MSPs, taking 30s+), which
+ * exceeds the gateway's tool-call timeout — so responses must never wait
+ * for it. The warm-up
+ * continues in the background and lands in the shared tenant store for
+ * subsequent requests.
+ */
+const WARM_WAIT_BUDGET_MS = 2_500;
+
+/**
+ * Cross-request cache store, keyed by tenant (lowercased API username).
+ *
+ * In gateway mode a new MappingService is constructed per request; without
+ * this store every request re-ran the full company pre-warm (30s+ on large
+ * tenants), stalling responses past the gateway timeout. Sharing the DATA
+ * keyed by tenant credential keeps requests fast while preserving the
+ * per-tenant isolation that the per-instance design exists to guarantee
+ * (incident 2026-06-03): two tenants can never share a store entry because
+ * the key IS the tenant identity.
+ */
+const tenantCacheStore = new Map<string, MappingCache>();
+
+/**
+ * Reset the tenant cache store. Intended for tests only.
+ */
+export function _resetTenantCacheStore(): void {
+  tenantCacheStore.clear();
+}
+
+function tenantCacheFor(tenantKey: string): MappingCache {
+  let entry = tenantCacheStore.get(tenantKey);
+  if (!entry) {
+    entry = {
+      companies: new Map<number, string>(),
+      resources: new Map<number, string>(),
+      lastUpdated: { companies: null, resources: null },
+    };
+    tenantCacheStore.set(tenantKey, entry);
+  }
+  return entry;
+}
+
 export class MappingService {
   // Per-instance init promise (coalesces concurrent initializeCache calls
   // on the SAME instance). Must NOT be static — a class-level singleton
@@ -37,25 +81,36 @@ export class MappingService {
   private cacheExpiryMs: number;
   // When true, skip the eager pre-warm and rely on per-ID direct-get fallbacks.
   private lazyLoading: boolean;
+  // Max time any caller may block on a cache warm-up/refresh before
+  // proceeding with whatever data is available. See WARM_WAIT_BUDGET_MS.
+  private warmWaitMs: number;
 
   public constructor(
     autotaskService: AutotaskService,
     logger: Logger,
     cacheExpiryMs: number = 30 * 60 * 1000,
     lazyLoading: boolean = false,
+    tenantKey?: string,
+    warmWaitMs: number = WARM_WAIT_BUDGET_MS,
   ) { // 30 minutes default
     this.autotaskService = autotaskService;
     this.logger = logger;
     this.cacheExpiryMs = cacheExpiryMs;
     this.lazyLoading = lazyLoading;
-    this.cache = {
-      companies: new Map<number, string>(),
-      resources: new Map<number, string>(),
-      lastUpdated: {
-        companies: null,
-        resources: null,
-      },
-    };
+    this.warmWaitMs = warmWaitMs;
+    // With a tenantKey, cache DATA is shared across instances of the same
+    // tenant via tenantCacheStore (see its doc comment). Without one (tests,
+    // or credentials not yet known), fall back to instance-local data.
+    this.cache = tenantKey
+      ? tenantCacheFor(tenantKey.toLowerCase())
+      : {
+          companies: new Map<number, string>(),
+          resources: new Map<number, string>(),
+          lastUpdated: {
+            companies: null,
+            resources: null,
+          },
+        };
   }
 
   /**
@@ -72,16 +127,54 @@ export class MappingService {
   public static async create(
     autotaskService: AutotaskService,
     logger: Logger,
-    options: { lazyLoading?: boolean } = {},
+    options: {
+      lazyLoading?: boolean;
+      tenantKey?: string | undefined;
+      warmWaitMs?: number | undefined;
+    } = {},
   ): Promise<MappingService> {
     const instance = new MappingService(
       autotaskService,
       logger,
       undefined,
       options.lazyLoading,
+      options.tenantKey,
+      options.warmWaitMs,
     );
-    await instance.ensureInitialized();
+    // Kick off the warm-up but only block for the budget: the full company
+    // pre-warm takes 30s+ on large tenants, which is longer than the
+    // gateway's tool-call timeout. If it doesn't finish in time, the caller
+    // proceeds with per-ID fallback lookups and the warm-up completes in
+    // the background (landing in the shared tenant store when keyed).
+    await instance.waitWithBudget(instance.ensureInitialized(), 'warm-up');
     return instance;
+  }
+
+  /**
+   * Await `work` for at most `warmWaitMs`, then proceed regardless. Errors
+   * are swallowed (logged upstream by the refresh methods) — mapping is a
+   * best-effort decoration and must never fail or stall the actual tool call.
+   */
+  private async waitWithBudget(work: Promise<void>, label: string): Promise<void> {
+    const settled = work.then(
+      () => true,
+      () => true,
+    );
+    if (this.warmWaitMs <= 0) return;
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = await Promise.race([
+      settled.then(() => false),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(true), this.warmWaitMs);
+        timer.unref?.();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (timedOut) {
+      this.logger.info(
+        `Mapping cache ${label} exceeded ${this.warmWaitMs}ms budget — continuing in background; this response uses fallback name lookups.`
+      );
+    }
   }
 
   /**
@@ -117,12 +210,14 @@ export class MappingService {
     }
 
     this.logger.info('Initializing mapping cache...');
+    // The refresh methods stamp lastUpdated themselves on their own success
+    // paths. Stamping unconditionally here would mark a FAILED warm-up as
+    // valid for the full expiry window — with the shared tenant store that
+    // would pin an empty cache on every request for that tenant.
     await Promise.all([
       this.refreshCompanyCache(),
       this.refreshResourceCache()
     ]);
-    this.cache.lastUpdated.companies = new Date();
-    this.cache.lastUpdated.resources = new Date();
     this.logger.info('Mapping cache initialized successfully', {
       companies: this.cache.companies.size,
       resources: this.cache.resources.size
@@ -167,7 +262,10 @@ export class MappingService {
    */
   public async getCompanyName(companyId: number): Promise<string | null> {
     try {
-      await this.refreshCacheIfNeeded();
+      // Budget-bounded: an expired cache triggers a refresh, but we serve
+      // the previous (stale) entries rather than stalling the response for
+      // the full re-walk — company names change rarely, timeouts hurt always.
+      await this.waitWithBudget(this.refreshCacheIfNeeded(), 'refresh');
 
       const cachedName = this.cache.companies.get(companyId);
       if (cachedName) {
@@ -195,7 +293,7 @@ export class MappingService {
    */
   public async getResourceName(resourceId: number): Promise<string | null> {
     try {
-      await this.refreshCacheIfNeeded();
+      await this.waitWithBudget(this.refreshCacheIfNeeded(), 'refresh');
       
       // Try cache first
       const cachedName = this.cache.resources.get(resourceId);

--- a/tests/mapping-tenant-store.test.ts
+++ b/tests/mapping-tenant-store.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for a gateway-timeout incident: in gateway mode a fresh
+ * MappingService per request re-ran the full company pre-warm (30s+ on
+ * tenants with thousands of companies) inside the tool-call response path,
+ * so every call for a large tenant exceeded the gateway timeout (-32603)
+ * while the Autotask API work itself succeeded.
+ *
+ * Fixes under test:
+ *  1. Cache DATA is shared across requests per tenant (keyed by lowercased
+ *     username) so the pre-warm runs once per expiry window, not per request.
+ *  2. Callers block on warm-up/refresh only up to a bounded budget; past it
+ *     they proceed with fallback lookups (cold) or stale entries (expired).
+ *  3. Tenant isolation still holds: different tenant keys never share data
+ *     (incident 2026-06-03).
+ */
+
+import { MappingService, _resetTenantCacheStore } from '../src/utils/mapping.service';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+
+jest.mock('../src/services/autotask.service');
+
+const mockLogger = new Logger('error');
+
+function makeMockService(overrides: Partial<Record<string, jest.Mock>> = {}): jest.Mocked<AutotaskService> {
+  return {
+    listAllCompanies: jest.fn().mockResolvedValue([
+      { id: 1, companyName: 'Acme Corp' },
+      { id: 2, companyName: 'Widget Inc' },
+    ]),
+    searchResources: jest.fn().mockResolvedValue([
+      { id: 10, firstName: 'John', lastName: 'Doe' },
+    ]),
+    getCompany: jest.fn().mockResolvedValue({ id: 3, companyName: 'Direct-Fetched Co' }),
+    getResource: jest.fn().mockResolvedValue({ id: 10, firstName: 'John', lastName: 'Doe' }),
+    ...overrides,
+  } as unknown as jest.Mocked<AutotaskService>;
+}
+
+/** A promise that never resolves — simulates a 30s+ company walk. */
+const hang = () => new Promise(() => { /* never settles */ });
+
+beforeEach(() => {
+  _resetTenantCacheStore();
+});
+
+describe('per-tenant shared cache store', () => {
+  it('reuses warmed data across create() calls for the SAME tenant (no re-walk)', async () => {
+    const svc1 = makeMockService();
+    const a = await MappingService.create(svc1, mockLogger, { tenantKey: 'user@tenant-a.com' });
+    expect(await a.getCompanyName(1)).toBe('Acme Corp');
+    expect(svc1.listAllCompanies).toHaveBeenCalledTimes(1);
+
+    // Simulates the next gateway request: new service + new MappingService,
+    // same tenant credentials.
+    const svc2 = makeMockService();
+    const b = await MappingService.create(svc2, mockLogger, { tenantKey: 'USER@TENANT-A.COM' });
+    expect(await b.getCompanyName(1)).toBe('Acme Corp');
+    // The second request must NOT have re-run the full walk.
+    expect(svc2.listAllCompanies).not.toHaveBeenCalled();
+  });
+
+  it('never shares data across DIFFERENT tenants (2026-06-03 isolation invariant)', async () => {
+    const svcA = makeMockService({
+      listAllCompanies: jest.fn().mockResolvedValue([{ id: 1, companyName: 'Tenant A Co' }]),
+    });
+    const svcB = makeMockService({
+      listAllCompanies: jest.fn().mockResolvedValue([{ id: 1, companyName: 'Tenant B Co' }]),
+    });
+
+    const a = await MappingService.create(svcA, mockLogger, { tenantKey: 'user@tenant-a.com' });
+    const b = await MappingService.create(svcB, mockLogger, { tenantKey: 'user@tenant-b.com' });
+
+    expect(await a.getCompanyName(1)).toBe('Tenant A Co');
+    expect(await b.getCompanyName(1)).toBe('Tenant B Co');
+    expect(svcA.listAllCompanies).toHaveBeenCalledTimes(1);
+    expect(svcB.listAllCompanies).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps instance-local data when no tenantKey is provided', async () => {
+    const svc1 = makeMockService();
+    const svc2 = makeMockService();
+    await MappingService.create(svc1, mockLogger);
+    await MappingService.create(svc2, mockLogger);
+    // Without a key there is nothing to share — both instances walk.
+    expect(svc1.listAllCompanies).toHaveBeenCalledTimes(1);
+    expect(svc2.listAllCompanies).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bounded warm-up budget', () => {
+  it('create() returns within the budget even when the company walk hangs', async () => {
+    const svc = makeMockService({
+      listAllCompanies: jest.fn().mockImplementation(hang),
+      searchResources: jest.fn().mockImplementation(hang),
+    });
+
+    const started = Date.now();
+    const instance = await MappingService.create(svc, mockLogger, {
+      tenantKey: 'user@big-tenant.com',
+      warmWaitMs: 50,
+    });
+    // Generous ceiling — the point is it doesn't wait for the hung walk.
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(instance).toBeInstanceOf(MappingService);
+  });
+
+  it('falls back to a direct per-ID lookup while the cold warm-up is still running', async () => {
+    const svc = makeMockService({
+      listAllCompanies: jest.fn().mockImplementation(hang),
+      searchResources: jest.fn().mockImplementation(hang),
+      getCompany: jest.fn().mockResolvedValue({ id: 7, companyName: 'Directly Fetched Co' }),
+    });
+
+    const instance = await MappingService.create(svc, mockLogger, {
+      tenantKey: 'user@big-tenant.com',
+      warmWaitMs: 50,
+    });
+    // Cache is cold (walk hung) — the name must still resolve via getCompany.
+    expect(await instance.getCompanyName(7)).toBe('Directly Fetched Co');
+    expect(svc.getCompany).toHaveBeenCalledWith(7);
+  });
+
+  it('serves stale entries instead of stalling when the cache has expired mid-refresh', async () => {
+    // Warm normally first.
+    const svc = makeMockService();
+    const warmed = new MappingService(svc, mockLogger, 1 /* 1ms expiry */, false, 'user@stale.com', 50);
+    await warmed.ensureInitialized();
+    expect(await warmed.getCompanyName(1)).toBe('Acme Corp');
+
+    // Expiry (1ms) has long passed; make the re-walk hang. A new request's
+    // instance shares the same tenant store entry.
+    const slowSvc = makeMockService({
+      listAllCompanies: jest.fn().mockImplementation(hang),
+      searchResources: jest.fn().mockImplementation(hang),
+    });
+    const next = new MappingService(slowSvc, mockLogger, 1, false, 'user@stale.com', 50);
+    const started = Date.now();
+    // Stale-while-revalidate: previous entries are still served.
+    expect(await next.getCompanyName(1)).toBe('Acme Corp');
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it('a failed warm-up is not stamped valid — the next call retries the refresh', async () => {
+    const failing = jest.fn().mockRejectedValue(new Error('zone down'));
+    const svc = makeMockService({
+      listAllCompanies: failing,
+      searchResources: jest.fn().mockRejectedValue(new Error('zone down')),
+    });
+
+    const instance = await MappingService.create(svc, mockLogger, { tenantKey: 'user@flaky.com' });
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    // The failure must not have marked companies as fresh: a subsequent
+    // lookup should attempt the walk again (previously initializeCache
+    // stamped lastUpdated unconditionally, pinning an empty cache for 30min).
+    failing.mockResolvedValue([{ id: 5, companyName: 'Recovered Co' }]);
+    expect(await instance.getCompanyName(5)).toBe('Recovered Co');
+    expect(failing).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem
In gateway mode, every tool call constructs a fresh `MappingService`, whose `create()` awaited a full `listAllCompanies()` pre-warm inside the tool-call response path. For tenants with thousands of companies that walk takes 30s+, so every call — including `test_connection` — exceeded the upstream tool-call timeout. Clients saw JSON-RPC `-32603` timeouts while server-side logs showed the underlying Autotask API work succeeding. (The per-request construction itself is deliberate — it fixed a cross-tenant cache-leak incident — so the fix must preserve that isolation.)

## Fix
1. **Per-tenant shared cache store** (`tenantCacheStore`, keyed by lowercased API username): the warm-up runs once per 30-min expiry window per tenant instead of once per request. The cross-tenant isolation invariant holds — the store key *is* the tenant credential; regression tests assert two tenants never share an entry.
2. **Bounded waits** (2.5s budget) on warm-up and refresh: cold cache → fast per-ID fallback lookups while the walk completes in the background; expired cache → serve stale names while revalidating. Failed warm-ups are no longer stamped `lastUpdated` (previously pinned an empty cache as "valid" for 30 min).
3. **Per-request HTTP timeout raised 30s → 60s** (`REQUEST_TIMEOUT_MS`): distant zones add RTT and 500-row query pages can run long; upstream callers enforce their own end-to-end budgets, so this is a hung-connection backstop only.

## Test plan
- [x] 6 new tests in `tests/mapping-tenant-store.test.ts`: same-tenant reuse (no re-walk), cross-tenant isolation, no-key instance-local behavior, bounded create() with hung walk, cold-cache fallback lookup, stale-while-revalidate, failed-warm-up retry.
- [x] Existing `tests/mapping.test.ts` (22 tests) unchanged and passing.
- [x] Full suite: 152/152 tests pass (6 suite-level failures are the pre-existing `@modelcontextprotocol/server` resolution issue in the local env, identical before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Q2RdHhdrqMuRoGJSGD9s