### PR TITLE
ci(deps): ignore typescript major-version bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,15 @@ updates:
         update-types: ["minor", "patch"]
     # Production MAJORS are intentionally NOT grouped → individual PRs, held for
     # human review (never auto-merged).
+    ignore:
+      # typescript 7.x breaks this fleet's toolchain: DTS emit (tsup/rollup-plugin-dts
+      # TS5101 baseUrl-deprecated-as-error), and typescript-eslint (still <6.1.0 as of
+      # 8.66.0, no TS7 support yet). Has broken main 3x on some repos because Dependabot
+      # has no memory of a prior manual revert and just re-proposes the same major again.
+      # Deliberate hold, not a permanent blind -- remove once typescript-eslint + the
+      # tsup/DTS toolchain support TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
Stop Dependabot from proposing typescript MAJOR-version bumps on this repo, until the fleet toolchain catches up.

## Why (fleet-wide rationale)
typescript 7.x breaks this fleets toolchain:
- DTS emit via tsup/rollup-plugin-dts throws `TS5101` ("baseUrl deprecated") as a hard error.
- typescript-eslint still caps its peer range below typescript 6.1.0 as of its latest 8.66.0 release -- no TS7 support yet.

Several repos in the fleet already had this manually fixed once (typescript pinned back down) only for Dependabot to re-propose and re-merge the exact same breaking major bump later, because Dependabot has no memory of a prior manual revert. This broke main on 5 repos tonight and was fixed manually; this PR is the permanent guard so it cannot recur on this repo.

This is a deliberate, temporary hold -- not a permanent blind. Remove the `ignore:` rule once typescript-eslint and the tsup/DTS toolchain support TS7.

## Change
Adds an `ignore:` block (sibling to the existing `groups:` block) to `.github/dependabot.yml` that ignores `typescript` major-version updates specifically. Minor/patch typescript updates continue to flow through the existing grouped dev-dependencies PR as before.

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"`
- [x] Diff reviewed -- only the intended 9-line insertion into `.github/dependabot.yml`, nothing else touched
- Config-only change, no application code/tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->