### PR TITLE
fix(rate-limit): per-tenant 429 cooldown gate — fail fast locally during cooldown

### DIFF
--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -98,6 +98,33 @@ function parseRetryAfter(headerValue: string | null): number {
   return DEFAULT_RETRY_AFTER_SECONDS;
 }
 
+/**
+ * Per-tenant 429 cooldown gate, keyed by lowercased API username.
+ *
+ * Observed in production: LLM clients ignore the "Do NOT retry" text in the
+ * rate-limit error and re-fire the same call within seconds, sending every
+ * retry upstream into a tenant already over Autotask's hourly threshold —
+ * which can extend the cooldown. Once a tenant gets a 429, we remember the
+ * Retry-After deadline and fail every request for that tenant fast and
+ * LOCALLY (no upstream call) until it passes. Retry-spamming then costs the
+ * tenant nothing.
+ *
+ * Module-level and keyed by tenant credential (same isolation reasoning as
+ * the zone cache): in gateway mode client instances are per-request, so an
+ * instance-level gate would never trip across calls.
+ */
+const rateLimitCooldowns = new Map<string, number>();
+
+/** Cap a bad/hostile Retry-After header so it can't lock a tenant out for long. */
+const MAX_COOLDOWN_MS = 5 * 60 * 1000;
+
+/**
+ * Reset the cooldown gate. Intended for tests only.
+ */
+export function _resetRateLimitCooldowns(): void {
+  rateLimitCooldowns.clear();
+}
+
 function assertSafeRelativePath(path: string): void {
   if (typeof path !== 'string' || path.length === 0) {
     throw new Error('Autotask rawRequest: path must be a non-empty string');
@@ -157,6 +184,24 @@ export class AutotaskHttpClient {
    * pageDetails.nextPageUrl pagination).
    */
   private async request<T>(method: string, path: string, body?: any, isZoneRetry = false): Promise<T> {
+    // Cooldown gate: while this tenant is inside a known 429 window, fail
+    // fast locally instead of sending more requests upstream. See
+    // rateLimitCooldowns.
+    const cooldownKey = this.username.toLowerCase();
+    const cooldownUntil = rateLimitCooldowns.get(cooldownKey);
+    if (cooldownUntil !== undefined) {
+      const remainingSeconds = Math.ceil((cooldownUntil - Date.now()) / 1000);
+      if (remainingSeconds > 0) {
+        throw new AutotaskRateLimitError(
+          `Autotask API threshold exceeded (HTTP 429) — this tenant is in a ${remainingSeconds}s cooldown and this call was NOT sent upstream. ` +
+          `Do NOT retry until the cooldown passes; retries cannot succeed and querying again immediately only delays recovery. ` +
+          `Wait ${remainingSeconds}s, or ask the user to narrow the workload (smaller date ranges, specific IDs).`,
+          remainingSeconds,
+        );
+      }
+      rateLimitCooldowns.delete(cooldownKey);
+    }
+
     const url = path.startsWith('http') ? path : `${await this.baseUrl()}${path.startsWith('/') ? '' : '/'}${path}`;
 
     this.logger.debug(`Autotask HTTP ${method} ${url}`);
@@ -209,6 +254,13 @@ export class AutotaskHttpClient {
       }
       if (response.status === 429) {
         const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+        // Arm the per-tenant cooldown gate so any further calls (including
+        // LLM retry-spam and mapping-cache lookups) fail fast locally until
+        // the window passes instead of piling onto the throttled tenant.
+        rateLimitCooldowns.set(
+          cooldownKey,
+          Date.now() + Math.min(retryAfter * 1000, MAX_COOLDOWN_MS),
+        );
         // Single-line message that LLMs will read verbatim — instruct against
         // retry, surface the wait, point at the underlying issue. The structured
         // `retryAfterSeconds` field lets handlers do programmatic things too.

--- a/tests/rate-limit-cooldown-gate.test.ts
+++ b/tests/rate-limit-cooldown-gate.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for the per-tenant 429 cooldown gate.
+ *
+ * Observed in production: after a tenant tripped Autotask's hourly API
+ * threshold, an LLM client ignored the "Do NOT retry" error text and
+ * re-fired the same calls within seconds — every retry going upstream into
+ * the throttled tenant, which can extend the cooldown. The gate remembers
+ * the Retry-After deadline per tenant (keyed by lowercased username, shared
+ * across gateway-mode per-request client instances) and fails calls fast
+ * and locally until it passes.
+ */
+
+import { AutotaskHttpClient, AutotaskRateLimitError, _resetRateLimitCooldowns } from '../src/services/autotask-http';
+import { _resetZoneUrlCache } from '../src/utils/config';
+
+const logger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+};
+
+const makeClient = (username = 'user@example.com') =>
+  new AutotaskHttpClient(
+    username,
+    'secret',
+    'integration-code',
+    'https://webservices28.autotask.net/ATServicesRest/',
+    logger as any
+  );
+
+const rateLimited = () =>
+  Promise.resolve({
+    ok: false,
+    status: 429,
+    headers: { get: (h: string) => (h.toLowerCase() === 'retry-after' ? '60' : null) },
+    text: async () => JSON.stringify({ errors: ['API threshold exceeded'] }),
+  } as any);
+
+const success = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    text: async () => JSON.stringify({ item: { id: 1 } }),
+  } as any);
+
+beforeEach(() => {
+  _resetRateLimitCooldowns();
+  _resetZoneUrlCache();
+  Object.values(logger).forEach((m: any) => m.mockReset?.());
+});
+
+describe('per-tenant 429 cooldown gate', () => {
+  it('fails fast locally (no upstream call) once the tenant has hit a 429', async () => {
+    const client = makeClient();
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockImplementation(rateLimited);
+
+    try {
+      await expect(client.get('Companies', 1)).rejects.toThrow(AutotaskRateLimitError);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Retry-spam: none of these may reach upstream during the cooldown.
+      await expect(client.get('Companies', 1)).rejects.toThrow(/NOT sent upstream/);
+      await expect(client.query('Tickets', [])).rejects.toThrow(AutotaskRateLimitError);
+      await expect(client.rawRequest('POST', '/TicketHistory/query', {})).rejects.toThrow(AutotaskRateLimitError);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('keeps the structured retryAfterSeconds on locally-failed calls', async () => {
+    const client = makeClient();
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockImplementation(rateLimited);
+
+    try {
+      await expect(client.get('Companies', 1)).rejects.toThrow(AutotaskRateLimitError);
+      const err = (await client.get('Companies', 2).catch((e) => e)) as AutotaskRateLimitError;
+      expect(err).toBeInstanceOf(AutotaskRateLimitError);
+      expect(err.retryAfterSeconds).toBeGreaterThan(0);
+      expect(err.retryAfterSeconds).toBeLessThanOrEqual(60);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('shares the cooldown across client instances of the SAME tenant (gateway mode)', async () => {
+    const first = makeClient('User@Tenant.com');
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockImplementation(rateLimited);
+
+    try {
+      await expect(first.get('Companies', 1)).rejects.toThrow(AutotaskRateLimitError);
+      // Next request builds a fresh client (as buildPerRequestHandlers does).
+      const second = makeClient('user@tenant.com');
+      await expect(second.get('Companies', 1)).rejects.toThrow(/NOT sent upstream/);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('does NOT gate other tenants', async () => {
+    const throttled = makeClient('throttled@tenant.com');
+    const fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockImplementationOnce(rateLimited)
+      .mockImplementation(success);
+
+    try {
+      await expect(throttled.get('Companies', 1)).rejects.toThrow(AutotaskRateLimitError);
+      const healthy = makeClient('healthy@tenant.com');
+      await expect(healthy.get('Companies', 1)).resolves.toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('lets requests through again after the cooldown expires', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    const client = makeClient();
+    const fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockImplementationOnce(rateLimited)
+      .mockImplementation(success);
+
+    try {
+      await expect(client.get('Companies', 1)).rejects.toThrow(AutotaskRateLimitError);
+      jest.advanceTimersByTime(61_000);
+      await expect(client.get('Companies', 1)).resolves.toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchMock.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('caps an oversized Retry-After header at the maximum cooldown', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    const client = makeClient();
+    const fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: { get: (h: string) => (h.toLowerCase() === 'retry-after' ? '86400' : null) },
+          text: async () => '',
+        } as any)
+      )
+      .mockImplementation(success);
+
+    try {
+      await expect(client.get('Companies', 1)).rejects.toThrow(AutotaskRateLimitError);
+      // 5 minutes (the cap) + a beat — the 24h header must not still gate us.
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1_000);
+      await expect(client.get('Companies', 1)).resolves.toEqual({ id: 1 });
+    } finally {
+      fetchMock.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -9,7 +9,7 @@
 //      LLM clients can stop retrying.
 
 import { AutotaskService } from '../src/services/autotask.service';
-import { AutotaskRateLimitError } from '../src/services/autotask-http';
+import { AutotaskRateLimitError, _resetRateLimitCooldowns } from '../src/services/autotask-http';
 import { AutotaskToolHandler } from '../src/handlers/tool.handler';
 import { Logger } from '../src/utils/logger';
 import type { McpServerConfig } from '../src/types/mcp';
@@ -43,6 +43,12 @@ function responseWith(status: number, body: any, headers: Record<string, string>
 
 describe('Rate limit handling (#69, #91)', () => {
   let fetchSpy: jest.SpiedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    // These tests reuse one username; the module-level per-tenant cooldown
+    // gate would otherwise leak a 429 window from one test into the next.
+    _resetRateLimitCooldowns();
+  });
 
   afterEach(() => {
     if (fetchSpy) fetchSpy.mockRestore();


### PR DESCRIPTION
## Problem
Production logs showed an LLM client ignoring the "Do NOT retry" instruction in our structured rate-limit error: after a tenant tripped Autotask's hourly API threshold, the client re-fired the same calls within seconds, sustained over several minutes — every retry going upstream into the already-throttled tenant, which per Autotask's threshold behavior can extend the cooldown. The mapping-cache per-ID fallback lookups added further upstream calls during the same window. Advisory error text alone is demonstrably not enough.

## Fix
`AutotaskHttpClient` now records each 429's `Retry-After` deadline in a module-level map keyed by lowercased API username (shared across gateway-mode per-request client instances — same isolation reasoning as the zone cache: the key *is* the tenant credential). While a tenant is inside its cooldown window, every request for that tenant fails fast **locally** with the structured `AutotaskRateLimitError` (including remaining seconds) and nothing is sent upstream — retry-spamming becomes harmless. `Retry-After` is capped at 5 minutes so a bad header can't lock a tenant out.

## Test plan
- [x] 6 new tests in `tests/rate-limit-cooldown-gate.test.ts`: local fail-fast with no upstream call, structured retryAfterSeconds preserved, cross-instance sharing for the same tenant, no cross-tenant gating, expiry lets requests through, oversized Retry-After capped.
- [x] Existing `tests/rate-limit.test.ts` updated to reset the gate between tests (shared username), all passing.
- [x] Full suite: 207/207 tests, 20/20 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Q2RdHhdrqMuRoGJSGD9s

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->