### PR TITLE
fix(quotes): searchQuotes company filter used nonexistent accountId field

### DIFF
--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -1824,13 +1824,17 @@ export class AutotaskService {
       this.logger.debug('Searching quotes with options:', options);
       const filters: QueryFilter[] = [];
       if (options.companyId) {
-        filters.push({ field: 'accountId', op: 'eq', value: options.companyId });
+        // The Quotes entity has NO account* field — its company link is
+        // `companyID` (confirmed via entityInformation/fields). Filtering on
+        // `accountId` returns HTTP 500 "Unable to find accountId in the
+        // Quote Entity" on every tenant.
+        filters.push({ field: 'companyID', op: 'eq', value: options.companyId });
       }
       if (options.contactId) {
-        filters.push({ field: 'contactId', op: 'eq', value: options.contactId });
+        filters.push({ field: 'contactID', op: 'eq', value: options.contactId });
       }
       if (options.opportunityId) {
-        filters.push({ field: 'opportunityId', op: 'eq', value: options.opportunityId });
+        filters.push({ field: 'opportunityID', op: 'eq', value: options.opportunityId });
       }
       if (options.searchTerm) {
         filters.push({ field: 'description', op: 'contains', value: options.searchTerm });

--- a/tests/search-quotes-fields.test.ts
+++ b/tests/search-quotes-fields.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test: searchQuotes filtered by companyId sent `accountId` as
+ * the filter field, but the Quotes entity has no account* field at all —
+ * its company link is `companyID` (verified against the live
+ * entityInformation/fields response). Autotask rejected every such query
+ * with HTTP 500 "Unable to find accountId in the Quote Entity", breaking
+ * autotask_search_quotes company filtering for every tenant.
+ */
+
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const mockLogger = new Logger('error');
+const config: McpServerConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  autotask: {
+    username: 'test-username',
+    secret: 'test-secret',
+    integrationCode: 'test-integration-code',
+    apiUrl: 'https://example.autotask.net/atservicesrest/',
+  },
+};
+
+const ok = (body: any) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    text: async () => JSON.stringify(body),
+  } as any);
+
+describe('searchQuotes filter field names', () => {
+  it('sends companyID (not accountId) when filtering by companyId', async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => ok({ items: [], pageDetails: {} }));
+
+    try {
+      const service = new AutotaskService(config, mockLogger);
+      await service.searchQuotes({ companyId: 42, contactId: 7, opportunityId: 9 });
+
+      const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+      const fields = body.filter.map((f: any) => f.field);
+      expect(fields).toEqual(['companyID', 'contactID', 'opportunityID']);
+      expect(fields).not.toContain('accountId');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem
Production logs showed `autotask_search_quotes` failing with HTTP 500 `Unable to find accountId in the Quote Entity` whenever a company filter was used. The Quotes entity has **no account\* field at all** — its company link is `companyID` (verified against the live `entityInformation/fields` response) — so company-filtered quote searches were broken for every tenant.

## Fix
- `companyId` option now maps to filter field `companyID`
- `contactId`/`opportunityId` aligned to the documented `contactID`/`opportunityID` casing

## Test plan
- [x] New regression test asserts the exact filter field names sent in the query body (`companyID`, `contactID`, `opportunityID`; never `accountId`)
- [x] `tests/autotask-service.test.ts` unaffected — 55/55 passing across both suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Q2RdHhdrqMuRoGJSGD9s

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->