### PR TITLE
fix: resolve completed tickets by exact ticket number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changed
 
+- **Exact ticket-number searches now include completed tickets.** `autotask_search_tickets` continues to exclude Complete (status 5) for broad searches, but a fully formed ticket number such as `T20260804.0026` now uses an equality filter and does not add the open-ticket default. This lets callers resolve historical/completed tickets by their human-facing number without requiring a separate status lookup or numeric Autotask record ID.
+
 - **Migrated from `@modelcontextprotocol/sdk` v1 to the v2 SDK (`@modelcontextprotocol/server` + `@modelcontextprotocol/node` 2.0.0-beta.5) with dual-era serving.** All three entrypoints now consume one shared per-request server factory (`AutotaskMcpServer.requestFactory()`), so the tool/resource/prompt surface can never drift between protocol eras:
   - **stdio** is served via `serveStdio(factory)` — the opening handshake pins the connection to its era (classic 2025 `initialize` or modern 2026-07-28).
   - **Node HTTP** is served via `createMcpHandler(factory, { legacy: 'stateless' })` wrapped with `toNodeHandler`. Modern 2026-07-28 envelope traffic is served natively; 2025-era traffic is served by the SDK's default stateless legacy fallback — a fresh server per request, the same per-request stateless idiom this server has always used. CORS, `/health`, and the gateway 401 credential gate are unchanged.

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -461,13 +461,13 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   // Ticket tools
   {
     name: 'autotask_search_tickets',
-    description: 'Search tickets by company, queue, status, priority. Use autotask_get_ticket_details for full data. Max 500/page.',
+    description: 'Search tickets by company, queue, status, priority, or ticket number. Broad searches default to open tickets; an exact ticket number also finds completed tickets. Use autotask_get_ticket_details for full data. Max 500/page.',
     inputSchema: {
       type: 'object',
       properties: {
         searchTerm: {
           type: 'string',
-          description: 'Search by ticket number prefix'
+          description: 'Search by ticket number or prefix. An exact ticket number (for example T20260804.0026) includes completed tickets; prefixes remain open-ticket searches by default.'
         },
         companyID: {
           type: 'number',

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -55,6 +55,12 @@ import { FieldInfo, PicklistValue } from './picklist.cache';
  */
 export const MATCH_ALL: QueryFilter[] = [{ op: 'gte', field: 'id', value: 0 }];
 
+// Autotask ticket numbers are normally TYYYYMMDD.NNNN. Some older tenants
+// use the compact TYYYYMMDD form, so both documented forms are recognized.
+// Exact ticket-number lookups must not inherit the broad-search open-only
+// default: a completed ticket is still a valid target for direct lookup.
+const EXACT_TICKET_NUMBER_PATTERN = /^T\d{8}(?:\.\d{4})?$/i;
+
 /**
  * Push an `eq` filter only when `value` is not `undefined`. Replaces the
  * `if (options.X !== undefined) filters.push({ op: 'eq', field: 'X', value: options.X })`
@@ -385,13 +391,20 @@ export class AutotaskService {
 
       const filters: QueryFilter[] = [];
 
+      const isExactTicketNumber = typeof options.searchTerm === 'string' &&
+        EXACT_TICKET_NUMBER_PATTERN.test(options.searchTerm);
+
       if (options.searchTerm) {
-        filters.push({ op: 'beginsWith', field: 'ticketNumber', value: options.searchTerm });
+        filters.push({
+          op: isExactTicketNumber ? 'eq' : 'beginsWith',
+          field: 'ticketNumber',
+          value: options.searchTerm,
+        });
       }
 
       if (options.status !== undefined) {
         filters.push({ op: 'eq', field: 'status', value: options.status });
-      } else {
+      } else if (!isExactTicketNumber) {
         filters.push({ op: 'noteq', field: 'status', value: 5 }); // 5 = Complete (Autotask REST uses 'noteq', not 'ne')
       }
 

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -1103,5 +1103,38 @@ describe('AutotaskService', () => {
       expect(capturedFilters).toContainEqual({ op: 'eq', field: 'status', value: 1 });
       expect(capturedFilters).not.toContainEqual({ op: 'noteq', field: 'status', value: 5 });
     });
+
+    test('searchTickets resolves an exact ticket number across all statuses', async () => {
+      let capturedFilters: any;
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+        capturedFilters = JSON.parse(init!.body as string).filter;
+        return jsonResponse({
+          items: [{ id: 86583, ticketNumber: 'T20260804.0026', status: 5 }],
+          pageDetails: { nextPageUrl: null },
+        });
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const result = await service.searchTickets({ searchTerm: 'T20260804.0026' } as any);
+
+      expect(result).toHaveLength(1);
+      expect(capturedFilters).toContainEqual({ op: 'eq', field: 'ticketNumber', value: 'T20260804.0026' });
+      expect(capturedFilters).not.toContainEqual({ op: 'beginsWith', field: 'ticketNumber', value: 'T20260804.0026' });
+      expect(capturedFilters).not.toContainEqual({ op: 'noteq', field: 'status', value: 5 });
+    });
+
+    test('searchTickets keeps prefix searches open-only', async () => {
+      let capturedFilters: any;
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+        capturedFilters = JSON.parse(init!.body as string).filter;
+        return jsonResponse({ items: [], pageDetails: { nextPageUrl: null } });
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchTickets({ searchTerm: 'T20260804' } as any);
+
+      expect(capturedFilters).toContainEqual({ op: 'beginsWith', field: 'ticketNumber', value: 'T20260804' });
+      expect(capturedFilters).toContainEqual({ op: 'noteq', field: 'status', value: 5 });
+    });
   });
 });

--- a/website/src/content/docs/examples/tickets.md
+++ b/website/src/content/docs/examples/tickets.md
@@ -44,6 +44,13 @@ description: Example prompts for searching, creating, and managing support ticke
 
 **What happens:** The server calls `autotask_search_tickets` with `searchTerm: "VPN connectivity"`.
 
+### Find a ticket by its ticket number
+
+**Prompt:**
+> "Find ticket T20260804.0026"
+
+**What happens:** An exact ticket-number search uses the ticket number equality filter and searches all statuses, including Complete. Ticket-number prefixes and other broad searches continue to default to open tickets unless a `status` is supplied.
+
 ### Filter by priority
 
 **Prompt:**

--- a/website/src/content/docs/reference/tools.md
+++ b/website/src/content/docs/reference/tools.md
@@ -30,7 +30,7 @@ The Autotask MCP Server exposes 39 tools organized by entity type.
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `autotask_search_tickets` | Search for tickets | `searchTerm`, `companyID`, `status`, `priority`, `queueID`, `assignedResourceID` |
+| `autotask_search_tickets` | Search for tickets; exact ticket numbers include completed tickets, while broad searches default to open tickets | `searchTerm`, `companyID`, `status`, `priority`, `queueID`, `assignedResourceID` |
 | `autotask_get_ticket_details` | Get full ticket details | `ticketId` (required) |
 | `autotask_create_ticket` | Create a new ticket | `title`, `companyID` (required), `priority`, `status`, `queueID`, `description` |
 


### PR DESCRIPTION
## Summary

Fix exact Autotask ticket-number lookups so completed tickets can be resolved by their human-facing number.

## Behavior

- Fully formed ticket numbers such as `T20260804.0026` use an equality filter and do not inherit the default `status != 5` filter.
- Ticket-number prefixes, keyword searches, and other broad searches remain open-ticket-only by default.
- Explicit `status` filters retain their existing behavior.
- Direct `autotask_get_ticket_details` remains numeric-ID based; callers can use the exact-number search result to obtain that ID.

## Root cause

The prior correction changed the invalid Autotask REST operator `ne` to `noteq`. That fixed completed tickets leaking into open searches, but it did not make exact human ticket-number lookups search completed tickets.

## Testing

- Added regression coverage for exact completed-ticket numbers and prefix-search preservation.
- `git diff --check` passes.
- Full dependency-backed checks are delegated to PR CI because the local environment cannot authenticate to the private `@wyre-technology/autotask-node` GitHub Packages dependency.

Required CI checks: `npm ci --ignore-scripts`, `npm test`, `npm run typecheck`, `npm run build`, `npm audit --omit=dev --audit-level=high`, and `git diff --check`.

## Functional impact

No change to broad/open-ticket search behavior. Exact ticket-number lookups now include completed tickets, which is required for historical ticket review.

## Rollback

Revert this PR or redeploy the previous image digest/revision. No database or Autotask data migration is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789319421&installation_model_id=431410&pr_number=251&repository=wyre-technology%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2Fwyre-technology%2Fautotask-mcp%2Fpull%2F251&signature=7e7383e13b3341e4ffbeb13065ff56280aa8b94f00dfe8a497a22d48b7bc11a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->