### PR TITLE
fix(ci): re-pin release workflow to the fixed digest-verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     # existed in this repo's hand-rolled workflow and was dropped by the
     # centralization in #183, so every release from v2.30.0 on shipped with no
     # assets while the README still pointed users at the bundle (#244).
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@ebbdf5a23203c35249e32cca64891ab94269ebb6
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@3b76ae043ead0d64a3a0a9f57631bf502bdc4dd4
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-technology/autotask-mcp


### PR DESCRIPTION
Unblocks the release chain. Follow-up to #247 and [wyre-technology/.github#45](https://github.com/wyre-technology/.github/pull/45).

## What broke

#247 bumped the reusable-workflow pin to `.github`'s then-current `main`, which pulled in **two** commits rather than one — my mcpb job, and `0e04141` ([#40](https://github.com/wyre-technology/.github/pull/40)), which added a digest-verification step. That step used an invalid template and failed:

```
template: :1:7: executing "" at <.Config>: can't evaluate field Config in type image
```

`docker buildx imagetools inspect --format` exposes only `.Name`, `.Manifest`, `.Image` — the image config is under `.Image`. v2.32.4 was the first release anywhere to reach that step.

Result for **v2.32.4**:

| | |
|---|---|
| `autotask-mcp.mcpb` attached | ✅ (#244 fixed) |
| image in GHCR | ✅ `sha256:4cc791b…`, tagged `v2.32.4` + `latest` |
| MCP Registry publish | ❌ skipped |
| deploy to production | ❌ skipped |

The image was fine; only the verification of it was broken.

## Fix

Re-pins to `3b76ae0`, which carries wyre-technology/.github#45 (`.Config` → `.Image.Config`, plus multi-arch map handling).

A re-run of v2.32.4's failed job would **not** have helped: a re-run resolves the reusable workflow at the SHA pinned in the caller *as of that commit*, so it would have re-executed the broken `ebbdf5a` version. A new commit is what picks up the fix — this one, which will cut v2.32.5 and carry the full chain through deploy.

## Pin hygiene

Range verified before bumping this time, which is the check whose absence caused this:

```
git log ebbdf5a..3b76ae0 -- .github/workflows/mcp-server-release.yml
3b76ae0 fix(release): use .Image.Config in the digest verify template (#45)
```

Exactly one commit, nothing riding along. `actionlint` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->