### PR TITLE
fix(ci): re-pin release workflow to the config-casing fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     # existed in this repo's hand-rolled workflow and was dropped by the
     # centralization in #183, so every release from v2.30.0 on shipped with no
     # assets while the README still pointed users at the bundle (#244).
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@3b76ae043ead0d64a3a0a9f57631bf502bdc4dd4
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8deff2993e933c45856861cb3491d251361a5a8a
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-technology/autotask-mcp


### PR DESCRIPTION
Unblocks the deploy chain. Follow-up to #252 and [wyre-technology/.github#46](https://github.com/wyre-technology/.github/pull/46).

v2.32.5 built and pushed a good image and attached its `.mcpb`, but the digest-verify step rejected it: the check tested `has("Config")` while the marshalled OCI image config uses **lowercase `config`**, so every single-platform build fell into the platform-map branch and hard-failed.

I pulled the rejected digest from GHCR by hand — `application/vnd.oci.image.manifest.v1+json`, image config, 12 layers. A genuine image, so this was a false positive, and it cascaded `mcp-registry`/`security`/`deploy` to skipped exactly as v2.32.4 did.

Fixed upstream in .github#46, this time verified against the real config blob from GHCR rather than fixtures I wrote (the previous attempt's fixtures encoded the same wrong assumption, which is why it shipped broken). Pin range checked before bumping: exactly one commit.

This will cut v2.32.6 and should carry the chain through `deploy` for the first time since v2.32.3.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->