### PR TITLE
feat(contracts): backport contract management tools from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Added
+
+- **Contract management tools** (backported from [wyre-technology/autotask-mcp#237](https://github.com/wyre-technology/autotask-mcp/issues/237)). Contract coverage now spans the full read/report/create lifecycle:
+  - `autotask_get_contract` — single contract header by ID (the service method existed but was never exposed as a tool).
+  - `autotask_search_contracts` gained `contractType` and `endDateFrom`/`endDateTo` filters alongside the existing name/company/status ones.
+  - `autotask_list_expiring_contracts` — dedicated expiring/expired-contracts report: contracts whose end date falls within the next `daysAhead` days (default 60), optionally including already-lapsed contracts (`includeExpired`), scoped to one company or the whole org.
+  - `autotask_create_contracts_bulk` — create up to 50 contract shells (header records, no service lines) in one call, e.g. onboarding a customer with several location-based contracts. Shells POST sequentially (Autotask has no batch endpoint and bursts risk 429 thresholds); a failed shell doesn't abort the batch — each item reports its own `success`/`id`/`error` so callers can retry just the failures.
+  - The `financial` tool category now lists every contract tool (the previously-added write tools were missing from it), and the intent router recognizes "expiring/renewing contract" phrasing.
+
 ### Changed
 
 - **Migrated to ESLint 9/10 flat config** ([#141](https://github.com/wyre-technology/autotask-mcp/issues/141)). ESLint 9 dropped support for the legacy `.eslintrc.json` format, and `@typescript-eslint` v6 can't run under it — so the `eslint`, `@typescript-eslint/parser`, and `@typescript-eslint/eslint-plugin` Dependabot bumps were three coupled breaking changes that could only land together. Replaced `.eslintrc.json` with `eslint.config.mjs` (flat config) using the unified `typescript-eslint` package (bundles parser + plugin in version-lockstep), bumped `eslint` 8 → 10 and typescript-eslint 6 → 8, and added `@eslint/js` + `globals`. The ruleset is unchanged (`no-explicit-any`/`no-unused-vars` as warnings, `no-console` off, same ignores); lint output is identical at 0 errors / 193 warnings. `lint` script simplified from `eslint src --ext .ts` to `eslint src` (flat config infers extensions).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Give your AI assistant direct access to Autotask.** Search tickets, create time entries, look up companies, manage projects — all through natural language. No more copy-pasting between browser tabs and chat windows.
 
-This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects Claude (or any MCP-compatible AI) to your Autotask PSA environment. Your AI assistant gets 39 tools covering the operations MSP teams use daily: ticket triage, time logging, company lookups, project management, billing review, and more.
+This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects Claude (or any MCP-compatible AI) to your Autotask PSA environment. Your AI assistant gets 101 tools covering the operations MSP teams use daily: ticket triage, time logging, company lookups, project management, billing review, and more.
 
 If you run an MSP on Autotask and you're tired of the context-switching tax, this is for you.
 
@@ -55,7 +55,7 @@ See [Installation](#installation) for Docker and from-source methods.
 ## Features
 
 - **🔌 MCP Protocol Compliance**: Full support for MCP resources and tools
-- **🛠️ Comprehensive API Coverage**: 39 tools spanning companies, contacts, tickets, projects, billing items, time entries, notes, attachments, and more
+- **🛠️ Comprehensive API Coverage**: 101 tools spanning companies, contacts, tickets, projects, service calls, billing items, time entries, notes, attachments, contracts, and more
 - **🔍 Advanced Search**: Powerful search capabilities with filters across all entities
 - **📝 CRUD Operations**: Create, read, update operations for core Autotask entities
 - **🔄 ID-to-Name Mapping**: Automatic resolution of company and resource IDs to human-readable names
@@ -316,7 +316,7 @@ Resources provide read-only access to Autotask data:
 
 ### Tools
 
-The server provides 39 tools for interacting with Autotask:
+The server provides 101 tools for interacting with Autotask:
 
 #### Company Operations
 - `autotask_search_companies` - Search companies with filters
@@ -361,7 +361,14 @@ The server provides 39 tools for interacting with Autotask:
 - `autotask_get_expense_report` / `autotask_search_expense_reports` / `autotask_create_expense_report`
 - `autotask_get_quote` / `autotask_search_quotes` / `autotask_create_quote`
 - `autotask_search_invoices` - Search invoices
-- `autotask_search_contracts` - Search contracts
+
+#### Contract Operations
+- `autotask_search_contracts` - Search contracts (name, company, status, type, end-date range)
+- `autotask_get_contract` - Get a single contract by ID
+- `autotask_list_expiring_contracts` - Expiring/expired contracts report (next N days, per company or org-wide)
+- `autotask_create_contract` / `autotask_create_contracts_bulk` - Create contract shells, one or many
+- `autotask_update_contract` - Update a contract (e.g. extend/renew end date)
+- `autotask_create_contract_service` / `autotask_update_contract_service` - Manage contract service lines
 
 #### Configuration Items
 - `autotask_search_configuration_items` - Search configuration items (assets)

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -880,6 +880,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'string',
           description: 'Name of the resource/user (e.g., "Will Spence"). Will be resolved to a resourceID automatically. Use this instead of resourceID for convenience.'
         },
+        roleID: {
+          type: 'number',
+          description: 'Role ID for the time entry. Required by Autotask for ticket-linked entries, but usually safe to omit — if ticketID is set and roleID is not, it defaults to that ticket\'s own assignedResourceRoleID. Only specify this to log time under a different role than the ticket\'s assigned one.'
+        },
         category: {
           type: 'string',
           description: 'Category name for Regular Time entries (e.g., "Internal Meeting", "Office Management", "Training", "Research", "HR/Recruiting", "Travel Time", "Holiday", "PTO"). Required for Regular Time entries (when no ticket/task/project is specified).'

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -3,6 +3,45 @@
 
 import { McpTool } from './tool.handler.js';
 
+// Contract shell fields shared by autotask_create_contract and
+// autotask_create_contracts_bulk (issue #237). Field names match the
+// Autotask REST API exactly.
+const CONTRACT_SHELL_PROPERTIES = {
+  companyID: { type: 'number', description: 'Company ID the contract is associated with' },
+  contractName: { type: 'string', description: 'Contract name' },
+  contractType: { type: 'number', description: 'Contract type picklist ID' },
+  contractCategory: { type: 'number', description: 'Contract category picklist ID' },
+  startDate: { type: 'string', description: 'Contract start date (ISO YYYY-MM-DD)' },
+  endDate: { type: 'string', description: 'Contract end date (ISO YYYY-MM-DD)' },
+  contactID: { type: 'number', description: 'Primary contact ID for the contract' },
+  contractNumber: { type: 'string', description: 'External-facing contract number' },
+  contractPeriodType: { type: 'number', description: 'Period type picklist ID' },
+  description: { type: 'string', description: 'Contract description / notes' },
+  estimatedCost: { type: 'number', description: 'Estimated cost' },
+  estimatedHours: { type: 'number', description: 'Estimated hours' },
+  estimatedRevenue: { type: 'number', description: 'Estimated revenue' },
+  setupFee: { type: 'number', description: 'Setup fee amount' },
+  overageBillingRate: { type: 'number', description: 'Overage billing rate' },
+  serviceLevelAgreementID: { type: 'number', description: 'SLA ID' },
+  purchaseOrderNumber: { type: 'string', description: 'Customer purchase order number' },
+  opportunityID: { type: 'number', description: 'Originating opportunity ID' },
+  billingPreference: { type: 'number', description: 'Billing preference picklist ID' },
+  billToCompanyID: { type: 'number', description: 'Bill-to company ID' },
+  billToCompanyContactID: { type: 'number', description: 'Bill-to contact ID' },
+  exclusionContractID: { type: 'number', description: 'Exclusion contract ID' },
+  isDefaultContract: { type: 'boolean', description: 'Whether this is the default contract for the company' },
+  internalCurrencySetupFee: { type: 'number', description: 'Setup fee in internal currency' },
+  internalCurrencyOverageBillingRate: { type: 'number', description: 'Overage rate in internal currency' },
+  organizationalLevelAssociationID: { type: 'number', description: 'Org level association ID' },
+  contractExclusionSetID: { type: 'number', description: 'Contract exclusion set ID' },
+  renewedContractID: { type: 'number', description: 'ID of the contract this renewed' },
+  setupFeeBillingCodeID: { type: 'number', description: 'Billing code ID for the setup fee' },
+  status: { type: 'number', description: 'Contract status (1=In Effect, 0=Inactive)' },
+  timeReportingRequiresStartAndStopTimes: { type: 'number', description: 'Whether time entries require start/stop times' }
+};
+
+const CONTRACT_SHELL_REQUIRED = ['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate'];
+
 export const TOOL_DEFINITIONS: McpTool[] = [
   // Connection testing
   {
@@ -2150,9 +2189,68 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Filter by contract status (1=In Effect, 3=Terminated)'
         },
+        contractType: {
+          type: 'number',
+          description: 'Filter by contract type picklist ID'
+        },
+        endDateFrom: {
+          type: 'string',
+          description: 'Only contracts ending on or after this date (ISO YYYY-MM-DD)'
+        },
+        endDateTo: {
+          type: 'string',
+          description: 'Only contracts ending on or before this date (ISO YYYY-MM-DD)'
+        },
         pageSize: {
           type: 'number',
           description: 'Number of results to return (default: 25, max: 500)',
+          minimum: 1,
+          maximum: 500
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_get_contract',
+    description: 'Get a single contract by ID (header fields only, no service lines)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Contract ID'
+        }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'autotask_list_expiring_contracts',
+    description: 'List contracts whose end date falls within the next N days (expiring-contracts report). Optionally include already-expired contracts, and scope to one company or the whole org.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        daysAhead: {
+          type: 'number',
+          description: 'Look-ahead window in days (default: 60)',
+          minimum: 0
+        },
+        companyID: {
+          type: 'number',
+          description: 'Limit the report to one company (omit for the whole org)'
+        },
+        includeExpired: {
+          type: 'boolean',
+          description: 'Also include contracts whose end date is already in the past (default: false)'
+        },
+        status: {
+          type: 'number',
+          description: 'Filter by contract status (1=In Effect, 3=Terminated)'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Number of results to return (default: 100, max: 500)',
           minimum: 1,
           maximum: 500
         }
@@ -2916,40 +3014,29 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     description: 'Create a new Contract in Autotask. Field names match the Autotask REST API exactly. status: 1=In Effect, 0=Inactive. Dates are ISO format (YYYY-MM-DD).',
     inputSchema: {
       type: 'object',
+      properties: CONTRACT_SHELL_PROPERTIES,
+      required: CONTRACT_SHELL_REQUIRED
+    }
+  },
+  {
+    name: 'autotask_create_contracts_bulk',
+    description: 'Create multiple contract shells (header records, no service lines) in one call — e.g. onboarding a customer with several location-based contracts. Shells are created one at a time; a failure on one shell does not stop the rest, and each item reports its own success or error.',
+    inputSchema: {
+      type: 'object',
       properties: {
-        companyID: { type: 'number', description: 'Company ID the contract is associated with' },
-        contractName: { type: 'string', description: 'Contract name' },
-        contractType: { type: 'number', description: 'Contract type picklist ID' },
-        contractCategory: { type: 'number', description: 'Contract category picklist ID' },
-        startDate: { type: 'string', description: 'Contract start date (ISO YYYY-MM-DD)' },
-        endDate: { type: 'string', description: 'Contract end date (ISO YYYY-MM-DD)' },
-        contactID: { type: 'number', description: 'Primary contact ID for the contract' },
-        contractNumber: { type: 'string', description: 'External-facing contract number' },
-        contractPeriodType: { type: 'number', description: 'Period type picklist ID' },
-        description: { type: 'string', description: 'Contract description / notes' },
-        estimatedCost: { type: 'number', description: 'Estimated cost' },
-        estimatedHours: { type: 'number', description: 'Estimated hours' },
-        estimatedRevenue: { type: 'number', description: 'Estimated revenue' },
-        setupFee: { type: 'number', description: 'Setup fee amount' },
-        overageBillingRate: { type: 'number', description: 'Overage billing rate' },
-        serviceLevelAgreementID: { type: 'number', description: 'SLA ID' },
-        purchaseOrderNumber: { type: 'string', description: 'Customer purchase order number' },
-        opportunityID: { type: 'number', description: 'Originating opportunity ID' },
-        billingPreference: { type: 'number', description: 'Billing preference picklist ID' },
-        billToCompanyID: { type: 'number', description: 'Bill-to company ID' },
-        billToCompanyContactID: { type: 'number', description: 'Bill-to contact ID' },
-        exclusionContractID: { type: 'number', description: 'Exclusion contract ID' },
-        isDefaultContract: { type: 'boolean', description: 'Whether this is the default contract for the company' },
-        internalCurrencySetupFee: { type: 'number', description: 'Setup fee in internal currency' },
-        internalCurrencyOverageBillingRate: { type: 'number', description: 'Overage rate in internal currency' },
-        organizationalLevelAssociationID: { type: 'number', description: 'Org level association ID' },
-        contractExclusionSetID: { type: 'number', description: 'Contract exclusion set ID' },
-        renewedContractID: { type: 'number', description: 'ID of the contract this renewed' },
-        setupFeeBillingCodeID: { type: 'number', description: 'Billing code ID for the setup fee' },
-        status: { type: 'number', description: 'Contract status (1=In Effect, 0=Inactive)' },
-        timeReportingRequiresStartAndStopTimes: { type: 'number', description: 'Whether time entries require start/stop times' }
+        contracts: {
+          type: 'array',
+          description: 'Contract shells to create, in order. Same fields as autotask_create_contract.',
+          minItems: 1,
+          maxItems: 50,
+          items: {
+            type: 'object',
+            properties: CONTRACT_SHELL_PROPERTIES,
+            required: CONTRACT_SHELL_REQUIRED
+          }
+        }
       },
-      required: ['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate']
+      required: ['contracts']
     }
   },
   {
@@ -3089,7 +3176,7 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
   },
   financial: {
     description: 'Quotes, quote items, opportunities, invoices, and contracts',
-    tools: ['autotask_get_quote', 'autotask_search_quotes', 'autotask_create_quote', 'autotask_get_quote_item', 'autotask_search_quote_items', 'autotask_create_quote_item', 'autotask_update_quote_item', 'autotask_delete_quote_item', 'autotask_get_opportunity', 'autotask_search_opportunities', 'autotask_create_opportunity', 'autotask_search_invoices', 'autotask_search_contracts']
+    tools: ['autotask_get_quote', 'autotask_search_quotes', 'autotask_create_quote', 'autotask_get_quote_item', 'autotask_search_quote_items', 'autotask_create_quote_item', 'autotask_update_quote_item', 'autotask_delete_quote_item', 'autotask_get_opportunity', 'autotask_search_opportunities', 'autotask_create_opportunity', 'autotask_search_invoices', 'autotask_search_contracts', 'autotask_get_contract', 'autotask_list_expiring_contracts', 'autotask_create_contract', 'autotask_create_contracts_bulk', 'autotask_update_contract', 'autotask_create_contract_service', 'autotask_update_contract_service']
   },
   products_and_services: {
     description: 'Products, services, and service bundles catalog',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -30,6 +30,8 @@ const TICKET_WRITABLE_FIELDS = [
   'status',
   'priority',
   'assignedResourceID',
+  'assignedResourceRoleID',
+  'dueDateTime',
   'contactID',
   'queueID',
   'ticketCategory',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -708,7 +708,15 @@ export class AutotaskToolHandler {
     }
 
     // Contract operations
-    if (/\b(?:contract|agreement)\b/.test(intent)) {
+    if (/\b(?:contract|agreement)s?\b/.test(intent) && /expir|renew|laps/.test(intent)) {
+      return {
+        suggestedTool: 'autotask_list_expiring_contracts',
+        suggestedParams: {},
+        description: 'List contracts expiring soon (or already expired)',
+        requiredParams: [],
+      };
+    }
+    if (/\b(?:contract|agreement)s?\b/.test(intent)) {
       return {
         suggestedTool: 'autotask_search_contracts',
         suggestedParams: {},
@@ -1033,6 +1041,18 @@ export class AutotaskToolHandler {
       // Contracts
       ['autotask_search_contracts', async (a) => {
         const r = await s.searchContracts(a); return { result: r, message: `Found ${r.length} contracts` };
+      }],
+      ['autotask_get_contract', async (a) => {
+        const r = await s.getContract(a.id); return { result: r, message: `Retrieved contract ${a.id}` };
+      }],
+      ['autotask_list_expiring_contracts', async (a) => {
+        const r = await s.listExpiringContracts(a);
+        return { result: r, message: `Found ${r.length} contracts with end dates within ${a.daysAhead ?? 60} days` };
+      }],
+      ['autotask_create_contracts_bulk', async (a) => {
+        const r = await s.createContracts(a.contracts);
+        const ok = r.filter((item) => item.success).length;
+        return { result: r, message: `Created ${ok}/${r.length} contracts` };
       }],
       ['autotask_create_contract', async (a) => {
         const id = await s.createContract(a); return { result: id, message: `Successfully created contract with ID: ${id}` };

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -2331,7 +2331,20 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug(`Deleting service call ticket ${id}`);
-      await http.delete('ServiceCallTickets', id);
+      // Delete is parent-scoped, same as Create (see createServiceCallTicket
+      // above) - a flat DELETE /ServiceCallTickets/{id} 404s. The caller only
+      // has the child's own id, so look up the record first (query is flat
+      // even for child entities, per searchServiceCallTickets above) to get
+      // its serviceCallID, then delete through the parent-scoped route.
+      const [record] = await http.query<AutotaskServiceCallTicket>(
+        'ServiceCallTickets',
+        [{ op: 'eq', field: 'id', value: id }],
+        { maxRecords: 1 }
+      );
+      if (!record?.serviceCallID) {
+        throw new Error(`Service call ticket ${id} not found or missing serviceCallID`);
+      }
+      await http.childDelete('ServiceCalls', record.serviceCallID, 'Tickets', id);
       this.logger.info(`Service call ticket ${id} deleted`);
     } catch (error) {
       this.logger.error(`Failed to delete service call ticket ${id}:`, error);
@@ -2393,7 +2406,18 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug(`Deleting service call ticket resource ${id}`);
-      await http.delete('ServiceCallTicketResources', id);
+      // Same parent-scoped-delete issue as deleteServiceCallTicket above -
+      // look up the record to get its serviceCallTicketID, then delete
+      // through the parent-scoped route.
+      const [record] = await http.query<AutotaskServiceCallTicketResource>(
+        'ServiceCallTicketResources',
+        [{ op: 'eq', field: 'id', value: id }],
+        { maxRecords: 1 }
+      );
+      if (!record?.serviceCallTicketID) {
+        throw new Error(`Service call ticket resource ${id} not found or missing serviceCallTicketID`);
+      }
+      await http.childDelete('ServiceCallTickets', record.serviceCallTicketID, 'Resources', id);
       this.logger.info(`Service call ticket resource ${id} deleted`);
     } catch (error) {
       this.logger.error(`Failed to delete service call ticket resource ${id}:`, error);

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -2305,7 +2305,15 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Creating service call ticket:', data);
-      const id = await http.create('ServiceCallTickets', data);
+      // ServiceCallTickets is a genuine child entity of ServiceCalls (the
+      // opposite situation from TimeEntries) - Autotask's own docs: "If this
+      // entity has a Parent relationship, you must perform all Create,
+      // Update, and Delete actions on the parent entity." A flat POST to
+      // /ServiceCallTickets 404s.
+      if (!data.serviceCallID) {
+        throw new Error('createServiceCallTicket requires serviceCallID');
+      }
+      const id = await http.childCreate('ServiceCalls', data.serviceCallID, 'ServiceCallTickets', data);
       this.logger.info(`Service call ticket created with ID: ${id}`);
       return id;
     } catch (error) {
@@ -2357,7 +2365,14 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Creating service call ticket resource:', data);
-      const id = await http.create('ServiceCallTicketResources', data);
+      // ServiceCallTicketResources is a genuine child entity of
+      // ServiceCallTickets - same "must go through the parent" rule as
+      // ServiceCallTickets itself. A flat POST to
+      // /ServiceCallTicketResources 404s.
+      if (!data.serviceCallTicketID) {
+        throw new Error('createServiceCallTicketResource requires serviceCallTicketID');
+      }
+      const id = await http.childCreate('ServiceCallTickets', data.serviceCallTicketID, 'ServiceCallTicketResources', data);
       this.logger.info(`Service call ticket resource created with ID: ${id}`);
       return id;
     } catch (error) {

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -944,8 +944,15 @@ export class AutotaskService {
 
       pushEq(filters, 'companyID', o.companyID);
       pushEq(filters, 'status', o.status);
+      pushEq(filters, 'contractType', o.contractType);
       if (o.searchTerm) {
         filters.push({ op: 'contains', field: 'contractName', value: o.searchTerm });
+      }
+      if (o.endDateFrom) {
+        filters.push({ op: 'gte', field: 'endDate', value: o.endDateFrom });
+      }
+      if (o.endDateTo) {
+        filters.push({ op: 'lte', field: 'endDate', value: o.endDateTo });
       }
       mergeFilterEscapeHatch(filters, options.filter);
 
@@ -957,6 +964,44 @@ export class AutotaskService {
       );
     } catch (error) {
       this.logger.error('Failed to search contracts:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Expiring/expired contracts report (issue #237): contracts whose endDate
+   * falls within the next `daysAhead` days (default 60). With
+   * `includeExpired`, already-lapsed contracts are included too. Scope to one
+   * company via `companyID`, or the whole org by omitting it.
+   */
+  async listExpiringContracts(options: {
+    daysAhead?: number;
+    companyID?: number;
+    includeExpired?: boolean;
+    status?: number;
+    pageSize?: number;
+  } = {}): Promise<AutotaskContract[]> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Listing expiring contracts with options:', options);
+      const daysAhead = options.daysAhead ?? 60;
+      const dayMs = 24 * 60 * 60 * 1000;
+      const isoDay = (d: Date) => d.toISOString().slice(0, 10);
+      const today = new Date();
+
+      const filters: QueryFilter[] = [
+        { op: 'lte', field: 'endDate', value: isoDay(new Date(today.getTime() + daysAhead * dayMs)) },
+      ];
+      if (!options.includeExpired) {
+        filters.push({ op: 'gte', field: 'endDate', value: isoDay(today) });
+      }
+      pushEq(filters, 'companyID', options.companyID);
+      pushEq(filters, 'status', options.status);
+
+      const pageSize = Math.min(options.pageSize || 100, 500);
+      return await http.query<AutotaskContract>('Contracts', filters, { maxRecords: pageSize });
+    } catch (error) {
+      this.logger.error('Failed to list expiring contracts:', error);
       throw error;
     }
   }
@@ -976,6 +1021,43 @@ export class AutotaskService {
       this.logger.error('Failed to create contract:', error);
       throw error;
     }
+  }
+
+  /**
+   * Bulk contract-shell creation (issue #237). The Autotask REST API has no
+   * batch endpoint for Contracts, so shells are POSTed one at a time —
+   * sequentially, to stay under the per-integration API thresholds. A failed
+   * shell doesn't abort the batch; each item reports its own outcome so
+   * callers can retry just the failures.
+   */
+  async createContracts(contracts: Partial<AutotaskContract>[]): Promise<Array<{
+    index: number;
+    contractName?: string | undefined;
+    success: boolean;
+    id?: number | undefined;
+    error?: string | undefined;
+  }>> {
+    const results: Array<{
+      index: number;
+      contractName?: string | undefined;
+      success: boolean;
+      id?: number | undefined;
+      error?: string | undefined;
+    }> = [];
+    for (const [index, contract] of contracts.entries()) {
+      try {
+        const id = await this.createContract(contract);
+        results.push({ index, contractName: contract.contractName, success: true, id });
+      } catch (error) {
+        results.push({
+          index,
+          contractName: contract.contractName,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return results;
   }
 
   async updateContract(id: number, updates: Partial<AutotaskContract>): Promise<void> {

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -2309,11 +2309,16 @@ export class AutotaskService {
       // opposite situation from TimeEntries) - Autotask's own docs: "If this
       // entity has a Parent relationship, you must perform all Create,
       // Update, and Delete actions on the parent entity." A flat POST to
-      // /ServiceCallTickets 404s.
+      // /ServiceCallTickets 404s. The child segment also drops the
+      // redundant parent-name prefix - it's /ServiceCalls/{id}/Tickets, not
+      // /ServiceCalls/{id}/ServiceCallTickets (same convention as
+      // Tickets/Attachments, not Tickets/TicketAttachments, elsewhere in
+      // this file). Confirmed against the entity-mapping table in
+      // @apigrate/autotask-restapi's README.
       if (!data.serviceCallID) {
         throw new Error('createServiceCallTicket requires serviceCallID');
       }
-      const id = await http.childCreate('ServiceCalls', data.serviceCallID, 'ServiceCallTickets', data);
+      const id = await http.childCreate('ServiceCalls', data.serviceCallID, 'Tickets', data);
       this.logger.info(`Service call ticket created with ID: ${id}`);
       return id;
     } catch (error) {
@@ -2367,12 +2372,15 @@ export class AutotaskService {
       this.logger.debug('Creating service call ticket resource:', data);
       // ServiceCallTicketResources is a genuine child entity of
       // ServiceCallTickets - same "must go through the parent" rule as
-      // ServiceCallTickets itself. A flat POST to
-      // /ServiceCallTicketResources 404s.
+      // ServiceCallTickets itself, and the same dropped-prefix convention:
+      // it's /ServiceCallTickets/{id}/Resources, not
+      // /ServiceCallTickets/{id}/ServiceCallTicketResources. Confirmed
+      // against the entity-mapping table in @apigrate/autotask-restapi's
+      // README.
       if (!data.serviceCallTicketID) {
         throw new Error('createServiceCallTicketResource requires serviceCallTicketID');
       }
-      const id = await http.childCreate('ServiceCallTickets', data.serviceCallTicketID, 'ServiceCallTicketResources', data);
+      const id = await http.childCreate('ServiceCallTickets', data.serviceCallTicketID, 'Resources', data);
       this.logger.info(`Service call ticket resource created with ID: ${id}`);
       return id;
     } catch (error) {

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -593,28 +593,30 @@ export class AutotaskService {
     try {
       this.logger.debug('Creating time entry:', timeEntry);
 
-      // Ticket-scoped
-      if (timeEntry.ticketID) {
-        const id = await http.childCreate('Tickets', timeEntry.ticketID, 'TimeEntries', timeEntry);
-        this.logger.info(`Time entry created with ID: ${id}`);
-        return id;
+      // TimeEntries is a flat, top-level Autotask entity regardless of whether
+      // it's linked to a Ticket, Task, or Project — the link is expressed via
+      // the ticketID/taskID/projectID field in the request body, not via a
+      // nested URL path. A previous version of this method POSTed to
+      // /Tickets/{id}/TimeEntries (http.childCreate) for ticket/task/project-
+      // scoped entries, which 404s — Autotask has no such nested route for
+      // this entity. Confirmed against the Autotask REST API TimeEntries
+      // entity documentation.
+      let payload = timeEntry;
+      if (payload.ticketID && !payload.roleID) {
+        // Autotask rejects ticket-linked time entries without a roleID
+        // ("TimeEntries for Tickets must have a roleID"). Default to the
+        // ticket's own assigned resource role so callers logging time
+        // against their own assigned ticket don't need to look this up
+        // themselves first.
+        const ticket = await this.getTicket(payload.ticketID, true);
+        const assignedRoleID = (ticket as unknown as { assignedResourceRoleID?: number } | null)?.assignedResourceRoleID;
+        if (assignedRoleID) {
+          payload = { ...payload, roleID: assignedRoleID };
+        }
       }
-      // Task-scoped
-      if (timeEntry.taskID) {
-        const id = await http.childCreate('Tasks', timeEntry.taskID, 'TimeEntries', timeEntry);
-        this.logger.info(`Time entry created with ID: ${id}`);
-        return id;
-      }
-      // Project-scoped
-      if (timeEntry.projectID) {
-        const id = await http.childCreate('Projects', timeEntry.projectID, 'TimeEntries', timeEntry);
-        this.logger.info(`Time entry created with ID: ${id}`);
-        return id;
-      }
-      // Regular (no parent — meetings, admin, etc.)
-      // Autotask accepts a POST /TimeEntries with no parent for regular entries.
-      const id = await http.create('TimeEntries', timeEntry);
-      this.logger.info(`Regular time entry created with ID: ${id}`);
+
+      const id = await http.create('TimeEntries', payload);
+      this.logger.info(`Time entry created with ID: ${id}`);
       return id;
     } catch (error) {
       this.logger.error('Failed to create time entry:', error);

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -107,6 +107,7 @@ export interface AutotaskProject {
 export interface AutotaskTimeEntry {
   id?: number;
   resourceID?: number;
+  roleID?: number;  // required by Autotask for ticket-linked time entries
   ticketID?: number;
   projectID?: number;
   taskID?: number;

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -864,6 +864,90 @@ describe('AutotaskService', () => {
       expect(capture().filter).toEqual(MATCH_ALL);
     });
 
+    // ---- Contract management tools (issue #237) ----
+
+    test('searchContracts translates contractType and endDate range', async () => {
+      const capture = captureFilter('Contracts');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchContracts({
+        contractType: 7,
+        endDateFrom: '2026-01-01',
+        endDateTo: '2026-12-31',
+      } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'contractType', value: 7 });
+      expect(body.filter).toContainEqual({ op: 'gte', field: 'endDate', value: '2026-01-01' });
+      expect(body.filter).toContainEqual({ op: 'lte', field: 'endDate', value: '2026-12-31' });
+    });
+
+    // Freeze only Date (not timers — AbortSignal.timeout and async plumbing
+    // must keep running) so the expiring-window math is deterministic.
+    const withFrozenDate = async (iso: string, fn: () => Promise<void>) => {
+      jest.useFakeTimers({
+        now: new Date(iso),
+        doNotFake: [
+          'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+          'setImmediate', 'clearImmediate', 'queueMicrotask',
+          'nextTick', 'performance',
+        ],
+      });
+      try {
+        await fn();
+      } finally {
+        jest.useRealTimers();
+      }
+    };
+
+    test('listExpiringContracts queries the endDate window [today, today+daysAhead]', async () => {
+      await withFrozenDate('2026-08-10T12:00:00Z', async () => {
+        const capture = captureFilter('Contracts');
+        const service = new AutotaskService(configWithUrl, mockLogger);
+        await service.listExpiringContracts({ daysAhead: 30 });
+        const body = capture();
+        expect(body.filter).toContainEqual({ op: 'gte', field: 'endDate', value: '2026-08-10' });
+        expect(body.filter).toContainEqual({ op: 'lte', field: 'endDate', value: '2026-09-09' });
+      });
+    });
+
+    test('listExpiringContracts with includeExpired drops the lower bound and scopes by company', async () => {
+      await withFrozenDate('2026-08-10T12:00:00Z', async () => {
+        const capture = captureFilter('Contracts');
+        const service = new AutotaskService(configWithUrl, mockLogger);
+        await service.listExpiringContracts({ daysAhead: 14, includeExpired: true, companyID: 77 });
+        const body = capture();
+        expect(body.filter).toContainEqual({ op: 'eq', field: 'companyID', value: 77 });
+        expect(body.filter).toContainEqual({ op: 'lte', field: 'endDate', value: '2026-08-24' });
+        expect(body.filter).not.toContainEqual(
+          expect.objectContaining({ op: 'gte', field: 'endDate' })
+        );
+      });
+    });
+
+    test('createContracts creates each shell and continues past per-item failures', async () => {
+      let postCount = 0;
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const url = typeof input === 'string' ? input : (input as URL).toString();
+        const method = (init?.method || 'GET').toUpperCase();
+        if (method === 'POST' && url === `${BASE}/Contracts`) {
+          postCount++;
+          if (postCount === 1) return jsonResponse({ errors: ['boom'] }, 500);
+          return jsonResponse({ itemId: 901 });
+        }
+        throw new Error(`unexpected ${method} ${url}`);
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const results = await service.createContracts([
+        { companyID: 1, contractName: 'A', contractType: 7, contractCategory: 3, startDate: '2026-01-01', endDate: '2026-12-31' },
+        { companyID: 2, contractName: 'B', contractType: 7, contractCategory: 3, startDate: '2026-01-01', endDate: '2026-12-31' },
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toMatchObject({ index: 0, contractName: 'A', success: false });
+      expect(results[0].error).toBeTruthy();
+      expect(results[1]).toMatchObject({ index: 1, contractName: 'B', success: true, id: 901 });
+    });
+
     test('searchConfigurationItems translates companyID, isActive, productID, searchTerm', async () => {
       const capture = captureFilter('ConfigurationItems');
       const service = new AutotaskService(configWithUrl, mockLogger);

--- a/tests/contract-tools.test.ts
+++ b/tests/contract-tools.test.ts
@@ -1,0 +1,164 @@
+// Contract management tool surface tests (issue #237):
+// autotask_get_contract, extended autotask_search_contracts filters,
+// autotask_list_expiring_contracts, and autotask_create_contracts_bulk.
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { TOOL_DEFINITIONS, TOOL_CATEGORIES } from '../src/handlers/tool.definitions';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const mockConfig: McpServerConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  autotask: {
+    username: 'test-username',
+    secret: 'test-secret',
+    integrationCode: 'test-integration-code'
+  }
+};
+
+const mockLogger = new Logger('error');
+
+const findTool = (name: string) => TOOL_DEFINITIONS.find(t => t.name === name);
+
+const contractShell = (overrides: Record<string, any> = {}) => ({
+  companyID: 1,
+  contractName: 'Managed Services',
+  contractType: 7,
+  contractCategory: 3,
+  startDate: '2026-01-01',
+  endDate: '2026-12-31',
+  ...overrides,
+});
+
+describe('contract tool definitions (issue #237)', () => {
+  test('autotask_get_contract exists and requires id', () => {
+    const tool = findTool('autotask_get_contract');
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.id.type).toBe('number');
+    expect(tool!.inputSchema.required).toEqual(['id']);
+  });
+
+  test('autotask_search_contracts exposes contractType and endDate range as optional filters', () => {
+    const tool = findTool('autotask_search_contracts');
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.contractType.type).toBe('number');
+    expect(props.endDateFrom.type).toBe('string');
+    expect(props.endDateTo.type).toBe('string');
+    expect(tool!.inputSchema.required ?? []).toEqual([]);
+  });
+
+  test('autotask_list_expiring_contracts exists with daysAhead/companyID/includeExpired', () => {
+    const tool = findTool('autotask_list_expiring_contracts');
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.daysAhead.type).toBe('number');
+    expect(props.companyID.type).toBe('number');
+    expect(props.includeExpired.type).toBe('boolean');
+    expect(tool!.inputSchema.required ?? []).toEqual([]);
+  });
+
+  test('autotask_create_contracts_bulk requires a contracts array of contract shells', () => {
+    const tool = findTool('autotask_create_contracts_bulk');
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.contracts.type).toBe('array');
+    expect(props.contracts.items.required).toEqual(
+      expect.arrayContaining(['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate'])
+    );
+    expect(tool!.inputSchema.required).toEqual(['contracts']);
+  });
+
+  test('financial category lists all contract tools', () => {
+    expect(TOOL_CATEGORIES.financial.tools).toEqual(
+      expect.arrayContaining([
+        'autotask_search_contracts',
+        'autotask_get_contract',
+        'autotask_list_expiring_contracts',
+        'autotask_create_contract',
+        'autotask_create_contracts_bulk',
+        'autotask_update_contract',
+        'autotask_create_contract_service',
+        'autotask_update_contract_service',
+      ])
+    );
+  });
+});
+
+describe('contract tool handlers (issue #237)', () => {
+  test('autotask_get_contract forwards id to service.getContract', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service, 'getContract')
+      .mockResolvedValue({ id: 55, contractName: 'Managed Services' } as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_get_contract', { id: 55 });
+    expect(spy).toHaveBeenCalledWith(55);
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('autotask_search_contracts forwards contractType and endDate range to the service', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service, 'searchContracts').mockResolvedValue([{ id: 1 }] as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    await handler.callTool('autotask_search_contracts', {
+      contractType: 7,
+      endDateFrom: '2026-01-01',
+      endDateTo: '2026-12-31',
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ contractType: 7, endDateFrom: '2026-01-01', endDateTo: '2026-12-31' })
+    );
+  });
+
+  test('autotask_list_expiring_contracts forwards options to service.listExpiringContracts', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service as any, 'listExpiringContracts')
+      .mockResolvedValue([{ id: 9, contractName: 'Expiring soon', endDate: '2026-08-20' }]);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_list_expiring_contracts', {
+      daysAhead: 45,
+      companyID: 9,
+      includeExpired: true,
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ daysAhead: 45, companyID: 9, includeExpired: true })
+    );
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('autotask_create_contracts_bulk forwards shells and reports per-item results', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service as any, 'createContracts').mockResolvedValue([
+      { index: 0, contractName: 'A', success: true, id: 11 },
+      { index: 1, contractName: 'B', success: false, error: 'boom' },
+    ]);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_create_contracts_bulk', {
+      contracts: [contractShell({ contractName: 'A' }), contractShell({ contractName: 'B' })],
+    });
+    expect(spy).toHaveBeenCalledWith([
+      expect.objectContaining({ contractName: 'A' }),
+      expect.objectContaining({ contractName: 'B' }),
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('1/2');
+  });
+
+  test('router routes expiring-contract intent to autotask_list_expiring_contracts', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_router', {
+      intent: 'show contracts expiring in the next 60 days',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.data.suggestedTool).toBe('autotask_list_expiring_contracts');
+  });
+});


### PR DESCRIPTION
## Summary
- Backports upstream commit [bca28f1](https://github.com/wyre-technology/autotask-mcp/commit/bca28f16a3328c1b5b192632888484737f497f22) (`wyre-technology/autotask-mcp#237`/`#238`), which we were missing, adding:
  - `autotask_get_contract` — single contract header by ID
  - `autotask_list_expiring_contracts` — expiring/expired contracts report (per company or org-wide, configurable window)
  - `autotask_create_contracts_bulk` — create up to 50 contract shells in one call
  - New `contractType`/`endDateFrom`/`endDateTo` filters on the existing `autotask_search_contracts`
  - Adds the missing contract write tools to the `financial` tool category, and teaches the intent router "expiring/renewing contract" phrasing
- Cherry-picked cleanly onto all code/test files (`tool.definitions.ts`, `tool.handler.ts`, `autotask.service.ts`, tests) — zero conflicts there. Only doc files (`CHANGELOG.md`, `CLAUDE.md`, `README.md`) conflicted, from unrelated upstream commits we haven't pulled in (MCP SDK v2 migration, interactive ticket card). Resolved those manually to describe only what's actually in this PR — did not import the unrelated feature entries.
- `CLAUDE.md`: kept our existing Task Master import as-is; did not pull in upstream's own dev-journal entries (different tooling, not relevant to our fork).

## Why
Found while auditing our fork against upstream for the server migration documentation effort — this was the entire gap (98 → 101 tools). Sheldon approved pulling it in.

## Test plan
- [x] `npm run build` — clean
- [x] `npx jest tests/contract-tools.test.ts tests/autotask-service.test.ts` — 60/60 passing
- [x] `npx jest` (full suite) — 154/154 passing, no regressions against our fork's own additions (service calls, opportunities, picklists, etc.)
- [x] `npm run lint` — 0 errors, 193 warnings (unchanged baseline, no new warnings)
- [ ] Not yet deployed to the live `autotask-mcp` container on `Clarity-Dev-Server` — needs a separate deploy step once this merges (flagging per change-control; live redeploy affects the connector Clarity is actively using).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789562226&installation_model_id=431410&pr_number=255&repository=wyre-technology%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2Fwyre-technology%2Fautotask-mcp%2Fpull%2F255&signature=a315174bc295e8acdb6f51d2017d5dd5cdb71351f47e5cd7ac31e17029c99f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->