### PR TITLE
fix(ci): bump mcp-server-release.yml pin to fix MCPB CLI install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     # existed in this repo's hand-rolled workflow and was dropped by the
     # centralization in #183, so every release from v2.30.0 on shipped with no
     # assets while the README still pointed users at the bundle (#244).
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8deff2993e933c45856861cb3491d251361a5a8a
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8bfc9b3a249fd1e6f69f1d05c45c8eaf3076fec3
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-technology/autotask-mcp


### PR DESCRIPTION
Bumps the shared release-workflow pin from 8deff2993e93 (2026-08-15, #46) to the current HEAD 8bfc9b3a249f (2026-08-17, #53).

This repo's Release runs would 404 packing the .mcpb bundle: `npx mcpb pack` fetches a nonexistent public package literally named `mcpb` (the real one is `@anthropic-ai/mcpb`). #53 in wyre-technology/.github fixed this upstream by installing the CLI explicitly before packing; repos pinned between #43 (which added the mcpb job, 08-13) and #53 (the fix, 08-17) still hit the bug.

Found via a full fleet audit after murph's ci-triage flagged the underlying shape (boss's ask, bus msg 1787242069568). 6 repos confirmed on this exact vulnerable pin: autotask-mcp, action1-mcp, connectwise-automate-mcp, atera-mcp, abnormal-mcp, blumira-mcp -- this PR is one of that set.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->