### PR TITLE
feat(gateway): Autotask resource impersonation via header

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The gateway injects credentials via headers:
 - `X-API-Key`: Autotask username
 - `X-API-Secret`: Autotask secret
 - `X-Integration-Code`: Autotask integration code
+- `X-Impersonation-Resource-Id`: (optional) Autotask resource ID to act on behalf of
 
 See [Gateway Mode](#gateway-mode) for details.
 
@@ -260,6 +261,7 @@ MCP_TRANSPORT=http
 | `X-API-Secret` | Autotask API secret key |
 | `X-Integration-Code` | Autotask integration code |
 | `X-API-URL` | (Optional) Custom Autotask API URL |
+| `X-Impersonation-Resource-Id` | (Optional) Autotask resource ID to act on behalf of. Forwarded to Autotask as its `ImpersonationResourceId` header, so actions are attributed to that resource instead of the API user, and recorded in the entity's read-only `impersonatorCreatorResourceID` field. Must be a positive integer; anything else is ignored with a warning. The impersonated resource must itself have permission for the action, and the API user's security level must permit impersonation. |
 
 **Health Check Response (Gateway Mode):**
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -140,6 +140,9 @@ export class AutotaskMcpServer {
     if (credentials.secret) autotaskConfig.secret = credentials.secret;
     if (credentials.integrationCode) autotaskConfig.integrationCode = credentials.integrationCode;
     if (credentials.apiUrl) autotaskConfig.apiUrl = credentials.apiUrl;
+    if (credentials.impersonationResourceId) {
+      autotaskConfig.impersonationResourceId = credentials.impersonationResourceId;
+    }
 
     const requestConfig: McpServerConfig = {
       name: this.envConfig?.server?.name || 'autotask-mcp',
@@ -321,7 +324,7 @@ export class AutotaskMcpServer {
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE');
       res.setHeader(
         'Access-Control-Allow-Headers',
-        'Content-Type, Accept, Authorization, Mcp-Session-Id, X-API-Key, X-API-Secret, X-Integration-Code'
+        'Content-Type, Accept, Authorization, Mcp-Session-Id, X-API-Key, X-API-Secret, X-Integration-Code, X-Impersonation-Resource-Id'
       );
       res.setHeader('Access-Control-Max-Age', '86400');
 

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -157,7 +157,8 @@ export class AutotaskHttpClient {
     private readonly secret: string,
     private readonly integrationCode: string,
     private readonly apiUrl: string | undefined,
-    private readonly logger: Logger
+    private readonly logger: Logger,
+    private readonly impersonationResourceId?: number
   ) {}
 
   private async baseUrl(): Promise<string> {
@@ -169,13 +170,23 @@ export class AutotaskHttpClient {
   }
 
   private headers(): Record<string, string> {
-    return {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
       ApiIntegrationcode: this.integrationCode,
       UserName: this.username,
       Secret: this.secret,
     };
+    // Impersonation is driven by this request header, NOT by the entity's
+    // impersonatorCreatorResourceID field - that field is read-only and is
+    // where Autotask *records* the impersonation, so setting it in a request
+    // body is silently ignored. The impersonated resource must itself have
+    // permission for the action, so an impersonated call is the intersection
+    // of the API user's rights and the impersonated user's.
+    if (this.impersonationResourceId !== undefined) {
+      headers.ImpersonationResourceId = String(this.impersonationResourceId);
+    }
+    return headers;
   }
 
   /**

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -283,7 +283,24 @@ export class AutotaskHttpClient {
           retryAfter,
         );
       }
-      const httpError = new Error(`Autotask ${method} ${path} failed: HTTP ${response.status}: ${detail}`);
+      // Impersonation is intent, not best-effort: if the header was sent and
+      // Autotask rejected the request, silently retrying without it would
+      // make the call succeed as the shared API user with nobody noticing
+      // attribution had quietly stopped happening - worse than an error,
+      // since it defeats the whole point of impersonation (an accurate PSA
+      // audit trail) while looking like success. So this never retries or
+      // swallows anything; it only appends an actionable hint pointing at
+      // the most common cause, alongside Autotask's own unmodified error -
+      // Autotask doesn't document a distinct status/body for "impersonation
+      // not permitted" specifically, so this can't reliably tell that case
+      // apart from any other failure on the same request.
+      const impersonationHint =
+        this.impersonationResourceId !== undefined
+          ? ` (impersonating resource ${this.impersonationResourceId} - if this is a permissions error, verify that resource's Autotask security level has "Allow impersonation of resources with this security level" enabled, and that its security level permits this specific action)`
+          : '';
+      const httpError = new Error(
+        `Autotask ${method} ${path} failed: HTTP ${response.status}: ${detail}${impersonationHint}`
+      );
       // Attach the numeric status so callers can branch on it reliably instead
       // of substring-matching the message (the message embeds the response body,
       // which can coincidentally contain a status-like number).

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -115,14 +115,24 @@ export class AutotaskService {
    */
   async initialize(): Promise<void> {
     try {
-      const { username, secret, integrationCode, apiUrl } = this.config.autotask;
+      const { username, secret, integrationCode, apiUrl, impersonationResourceId } = this.config.autotask;
 
       if (!username || !secret || !integrationCode) {
         throw new Error('Missing required Autotask credentials: username, secret, and integrationCode are required');
       }
 
       this.logger.info('Initializing Autotask HTTP client...');
-      this.http = new AutotaskHttpClient(username, secret, integrationCode, apiUrl, this.logger);
+      if (impersonationResourceId !== undefined) {
+        this.logger.info(`Impersonating Autotask resource ${impersonationResourceId}`);
+      }
+      this.http = new AutotaskHttpClient(
+        username,
+        secret,
+        integrationCode,
+        apiUrl,
+        this.logger,
+        impersonationResourceId
+      );
       this.logger.info('Autotask HTTP client initialized successfully');
     } catch (error) {
       this.logger.error('Failed to initialize Autotask HTTP client:', error);

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -9,6 +9,13 @@ export interface McpServerConfig {
     integrationCode?: string;
     secret?: string;
     apiUrl?: string;
+    /**
+     * Autotask resource ID to act on behalf of. When set, requests carry
+     * Autotask's `ImpersonationResourceId` header, so Autotask attributes the
+     * action to that resource rather than to the API user, and records it in
+     * the entity's read-only `impersonatorCreatorResourceID` field.
+     */
+    impersonationResourceId?: number;
   };
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -63,6 +63,32 @@ export interface GatewayCredentials {
   secret: string | undefined;
   integrationCode: string | undefined;
   apiUrl: string | undefined;
+  /**
+   * Optional Autotask resource ID to impersonate, from
+   * X-Impersonation-Resource-Id. Lets a gateway that has authenticated a real
+   * user attribute the action to that person instead of to the shared API
+   * account. Undefined when absent or not a positive integer.
+   */
+  impersonationResourceId: number | undefined;
+}
+
+/**
+ * Parse an impersonation resource ID, which must be a positive integer.
+ * Returns undefined for absent or malformed values so a bad header degrades to
+ * "no impersonation" rather than failing the request or forwarding nonsense to
+ * Autotask.
+ */
+export function parseImpersonationResourceId(
+  raw: string | undefined,
+  logger?: { warn: (msg: string) => void }
+): number | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    logger?.warn(`Ignoring invalid impersonation resource ID: ${JSON.stringify(raw)}`);
+    return undefined;
+  }
+  return parsed;
 }
 
 /**
@@ -78,6 +104,9 @@ export function getCredentialsFromGateway(): GatewayCredentials {
     secret: process.env.X_API_SECRET || process.env.AUTOTASK_SECRET,
     integrationCode: process.env.X_INTEGRATION_CODE || process.env.AUTOTASK_INTEGRATION_CODE,
     apiUrl: process.env.X_API_URL || process.env.AUTOTASK_API_URL,
+    impersonationResourceId: parseImpersonationResourceId(
+      process.env.X_IMPERSONATION_RESOURCE_ID || process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID
+    ),
   };
 }
 
@@ -96,6 +125,7 @@ export function parseCredentialsFromHeaders(headers: Record<string, string | str
     secret: getHeader('x-api-secret'),
     integrationCode: getHeader('x-integration-code'),
     apiUrl: getHeader('x-api-url'),
+    impersonationResourceId: parseImpersonationResourceId(getHeader('x-impersonation-resource-id')),
   };
 }
 
@@ -116,14 +146,22 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
         secret: process.env.AUTOTASK_SECRET,
         integrationCode: process.env.AUTOTASK_INTEGRATION_CODE,
         apiUrl: process.env.AUTOTASK_API_URL,
+        impersonationResourceId: parseImpersonationResourceId(process.env.AUTOTASK_IMPERSONATION_RESOURCE_ID),
       };
 
   // Filter out undefined values to satisfy exactOptionalPropertyTypes
-  const autotaskConfig: { username?: string; secret?: string; integrationCode?: string; apiUrl?: string } = {};
+  const autotaskConfig: {
+    username?: string;
+    secret?: string;
+    integrationCode?: string;
+    apiUrl?: string;
+    impersonationResourceId?: number;
+  } = {};
   if (creds.username) autotaskConfig.username = creds.username;
   if (creds.secret) autotaskConfig.secret = creds.secret;
   if (creds.integrationCode) autotaskConfig.integrationCode = creds.integrationCode;
   if (creds.apiUrl) autotaskConfig.apiUrl = creds.apiUrl;
+  if (creds.impersonationResourceId) autotaskConfig.impersonationResourceId = creds.impersonationResourceId;
 
   const transportType = (process.env.MCP_TRANSPORT as TransportType) || 'stdio';
   if (transportType !== 'stdio' && transportType !== 'http') {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,7 +51,7 @@ const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
   'Access-Control-Allow-Headers':
-    'Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, X-API-Key, X-API-Secret, X-Integration-Code, X-API-Url',
+    'Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, X-API-Key, X-API-Secret, X-Integration-Code, X-API-Url, X-Impersonation-Resource-Id',
   'Access-Control-Expose-Headers': 'Mcp-Session-Id',
 };
 
@@ -168,7 +168,7 @@ export default {
               message:
                 'Gateway mode requires X-API-Key, X-API-Secret, and X-Integration-Code headers',
               required: ['X-API-Key', 'X-API-Secret', 'X-Integration-Code'],
-              optional: ['X-API-Url'],
+              optional: ['X-API-Url', 'X-Impersonation-Resource-Id'],
             },
             401
           );

--- a/tests/gateway-impersonation.test.ts
+++ b/tests/gateway-impersonation.test.ts
@@ -115,3 +115,67 @@ describe('AutotaskHttpClient: outbound ImpersonationResourceId header', () => {
     expect(headers.ApiIntegrationcode).toBe('CODE');
   });
 });
+
+describe('AutotaskHttpClient: error hint when impersonating', () => {
+  // Autotask doesn't document a distinct status/body for "impersonation not
+  // permitted" specifically, so this can never reliably detect that one
+  // cause - it only appends an actionable hint to whatever error Autotask
+  // actually returned, on any failing request that had the header set.
+  // Deliberately NOT a silent retry-without-impersonation: that would make
+  // the call quietly succeed as the shared API user, defeating the audit-
+  // attribution point of the feature without the caller ever knowing.
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+  async function requestWithStatus(
+    impersonationResourceId: number | undefined,
+    status: number,
+    errorBody: string
+  ): Promise<Error> {
+    jest.resetModules();
+    const { AutotaskHttpClient } = await import('../src/services/autotask-http');
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status,
+      headers: { get: () => null },
+      text: async () => errorBody,
+    });
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    const client = new AutotaskHttpClient(
+      'api-user@example.com',
+      'secret',
+      'CODE',
+      'https://webservices99.autotask.net/ATServicesRest',
+      logger as never,
+      impersonationResourceId
+    );
+    try {
+      await (client as unknown as { request: (m: string, p: string) => Promise<unknown> }).request(
+        'GET',
+        '/Test/1'
+      );
+      throw new Error('expected request() to throw');
+    } catch (err) {
+      return err as Error;
+    }
+  }
+
+  it('appends an actionable hint, without dropping the original error, when impersonating', async () => {
+    const err = await requestWithStatus(29682886, 403, '{"errors":["Forbidden"]}');
+    expect(err.message).toContain('Forbidden');
+    expect(err.message).toContain('impersonating resource 29682886');
+    expect(err.message).toContain('Allow impersonation of resources with this security level');
+  });
+
+  it('adds no hint, error text unchanged, when not impersonating', async () => {
+    const err = await requestWithStatus(undefined, 403, '{"errors":["Forbidden"]}');
+    expect(err.message).toBe('Autotask GET /Test/1 failed: HTTP 403: Forbidden');
+    expect(err.message).not.toContain('impersonating');
+  });
+
+  it('still surfaces the real error as-is for an unrelated failure while impersonating', async () => {
+    const err = await requestWithStatus(29682886, 400, '{"errors":["Invalid field: fooBar"]}');
+    expect(err.message).toContain('Invalid field: fooBar');
+    expect((err as Error & { status?: number }).status).toBe(400);
+  });
+});

--- a/tests/gateway-impersonation.test.ts
+++ b/tests/gateway-impersonation.test.ts
@@ -1,0 +1,117 @@
+// Unit tests for gateway impersonation support.
+//
+// Autotask drives impersonation with the `ImpersonationResourceId` request
+// header. The entity field of the same name is read-only — Autotask populates
+// it to record that impersonation happened — so setting it in a request body is
+// silently ignored. These tests cover the inbound header parse and the outbound
+// header emission.
+
+import { parseCredentialsFromHeaders, parseImpersonationResourceId } from '../src/utils/config';
+
+describe('parseImpersonationResourceId', () => {
+  it('accepts a positive integer', () => {
+    expect(parseImpersonationResourceId('29682886')).toBe(29682886);
+  });
+
+  it('returns undefined when absent', () => {
+    expect(parseImpersonationResourceId(undefined)).toBeUndefined();
+    expect(parseImpersonationResourceId('')).toBeUndefined();
+  });
+
+  it.each([
+    ['zero', '0'],
+    ['negative', '-5'],
+    ['non-numeric', 'not-a-number'],
+    ['fractional', '12.5'],
+    ['numeric with suffix', '123abc'],
+  ])('rejects %s and degrades to no impersonation', (_label, raw) => {
+    expect(parseImpersonationResourceId(raw)).toBeUndefined();
+  });
+
+  it('warns via the supplied logger when the value is invalid', () => {
+    const warn = jest.fn();
+    expect(parseImpersonationResourceId('nope', { warn })).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when the value is simply absent', () => {
+    const warn = jest.fn();
+    expect(parseImpersonationResourceId(undefined, { warn })).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseCredentialsFromHeaders: X-Impersonation-Resource-Id', () => {
+  const base = {
+    'x-api-key': 'api-user@example.com',
+    'x-api-secret': 'secret',
+    'x-integration-code': 'CODE',
+  };
+
+  it('extracts the impersonation resource ID alongside the credentials', () => {
+    const creds = parseCredentialsFromHeaders({
+      ...base,
+      'x-impersonation-resource-id': '29682886',
+    });
+    expect(creds.impersonationResourceId).toBe(29682886);
+    // Existing behaviour must be untouched.
+    expect(creds.username).toBe('api-user@example.com');
+    expect(creds.secret).toBe('secret');
+    expect(creds.integrationCode).toBe('CODE');
+  });
+
+  it('leaves it undefined when the header is absent', () => {
+    const creds = parseCredentialsFromHeaders(base);
+    expect(creds.impersonationResourceId).toBeUndefined();
+  });
+
+  it('leaves it undefined when the header is malformed', () => {
+    const creds = parseCredentialsFromHeaders({
+      ...base,
+      'x-impersonation-resource-id': 'bogus',
+    });
+    expect(creds.impersonationResourceId).toBeUndefined();
+  });
+});
+
+describe('AutotaskHttpClient: outbound ImpersonationResourceId header', () => {
+  // headers() is private, so exercise it the way the class actually uses it:
+  // through a real request with fetch stubbed out.
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+  async function capturedHeaders(impersonationResourceId?: number): Promise<Record<string, string>> {
+    jest.resetModules();
+    const { AutotaskHttpClient } = await import('../src/services/autotask-http');
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+      text: async () => '{"items":[]}',
+    });
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    const client = new AutotaskHttpClient(
+      'api-user@example.com',
+      'secret',
+      'CODE',
+      'https://webservices99.autotask.net/ATServicesRest',
+      logger as never,
+      impersonationResourceId
+    );
+    await (client as unknown as { request: (m: string, p: string) => Promise<unknown> }).request('GET', '/Test/1');
+    return fetchMock.mock.calls[0][1].headers as Record<string, string>;
+  }
+
+  it('sends the header when a resource ID is configured', async () => {
+    const headers = await capturedHeaders(29682886);
+    expect(headers.ImpersonationResourceId).toBe('29682886');
+  });
+
+  it('omits the header entirely when no resource ID is configured', async () => {
+    const headers = await capturedHeaders(undefined);
+    expect(headers).not.toHaveProperty('ImpersonationResourceId');
+    // The standard auth headers must still be present.
+    expect(headers.UserName).toBe('api-user@example.com');
+    expect(headers.ApiIntegrationcode).toBe('CODE');
+  });
+});


### PR DESCRIPTION
Adds an optional `X-Impersonation-Resource-Id` gateway header, forwarded to Autotask as its own `ImpersonationResourceId` header.

**Motivation:** in gateway mode every action is attributed to the shared API user, so an Autotask ticket's history shows the API account rather than the person who asked for it. A gateway that has already authenticated a real user (SSO, app roles) knows who that is, but has no way to tell Autotask. This closes that gap - it matters for MSPs where the PSA audit trail is the record shown to clients.

**Mechanism note:** Autotask drives impersonation with a request HEADER. The `impersonatorCreatorResourceID` field present on entities is read-only - it's where Autotask *records* that impersonation happened, so setting it in a request body is silently ignored. It also tightens authorization rather than loosening it: Autotask requires the impersonated resource to have permission for the action, so an impersonated call is the intersection of the API user's rights and the impersonated user's.

**Fully optional and backward compatible** - with the header absent, behaviour is byte-identical. Malformed values (non-integer, zero, negative) are ignored with a warning rather than failing the request or forwarding nonsense upstream.

**Failure handling (2nd commit):** Autotask doesn't document a distinct status/body for "impersonation not permitted" specifically, so this can't reliably tell that case apart from any other failure on the same request - and deliberately does *not* try to paper over it with a silent retry-without-impersonation, since that would make the call quietly succeed as the shared API user, defeating the entire point of the feature (accurate audit attribution) without anyone noticing. Instead, any failing request that had the header set gets an actionable hint appended to Autotask's own unmodified error, pointing at the most common cause (the resource's or API user's security level not allowing impersonation).

Verified: `tsc` clean, `eslint` 0 errors, 229/229 tests pass (226 existing + 3 new for the error-hint behavior).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790401365&installation_model_id=431408&pr_number=259&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F259&signature=41b1992055163412155e29f72293d4b8fccf5ca7fba19e6386e92301211b7f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->