### PR TITLE
ci(release): bump mcp-server-release.yml pin to pick up cosign/sigstore verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     # existed in this repo's hand-rolled workflow and was dropped by the
     # centralization in #183, so every release from v2.30.0 on shipped with no
     # assets while the README still pointed users at the bundle (#244).
-    uses: WYRE-AI/.github/.github/workflows/mcp-server-release.yml@07bc1921cbd01ad8a079fe8a3dd28180080870d5
+    uses: WYRE-AI/.github/.github/workflows/mcp-server-release.yml@8c2360058e882a8afacfc4cebf840135789ef406
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-ai/autotask-mcp
@@ -49,7 +49,7 @@ jobs:
   #   permissions:
   #     id-token: write
   #     contents: read
-  #   uses: WYRE-AI/.github/.github/workflows/mcp-server-deploy.yml@07bc1921cbd01ad8a079fe8a3dd28180080870d5
+  #   uses: WYRE-AI/.github/.github/workflows/mcp-server-deploy.yml@8c2360058e882a8afacfc4cebf840135789ef406
   #   with:
   #     vendor-slug: autotask
   #     image-name: ghcr.io/wyre-ai/autotask-mcp


### PR DESCRIPTION
## Summary

Bumps the pinned `WYRE-AI/.github/.github/workflows/mcp-server-release.yml` reusable-workflow commit from `07bc1921` to `8c236005` (current main tip).

`07bc1921` (2026-08-24) predates `WYRE-AI/.github#2` (merged 2026-08-27, warden's Gate-3-reviewed fix), which added cosign/Sigstore signature verification of the `mcp-publisher` binary before extraction — until this bump, this repo's release job installs `mcp-publisher` with **zero pin, checksum, or signature check**. `8c236005` is 3 commits past the fix; those 3 commits don't touch `mcp-server-release.yml` (confirmed via diff), so it's safe to bump straight to current tip rather than pin to the fix commit exactly.

**Identical mechanical change across all affected `*-mcp` repos** (found via a full org enumeration cross-checked with warden's independent scan — 53 repos, same result). Part of a coordinated class-ask, not merged individually; holding for the batched Aaron authorization (mcp repos are walled).

## Test plan

- [x] Confirmed the new sha's file content includes the cosign verify-blob step (diffed directly, not inferred)
- [x] Confirmed the 3 commits between the fix and this bump's target don't touch the reusable workflow file
- N/A — no functional test beyond the workflow reference itself; CI will exercise the new pin on the next real release from this repo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790609788&installation_model_id=431408&pr_number=265&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F265&signature=414c2ca0cb06f0d5304d9d728f42216263414e3217c641e90470e96dca07c547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->