### PR TITLE
ci: repoint reusable release workflow to public WYRE-AI/reusable-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,12 @@ on:
 
 # Thin caller for the canonical reusable release pipeline. The build →
 # semantic-release → Docker → MCP Registry → security chain (tag-based release
-# detection + correct gating) lives in WYRE-AI/.github so every *-mcp
-# repo stays in lockstep instead of drifting per-repo. PR-time lint/test gating
+# detection + correct gating) lives in WYRE-AI/reusable-workflows so every
+# *-mcp repo stays in lockstep instead of drifting per-repo. That host repo is
+# PUBLIC by necessity: GitHub refuses to resolve a reusable workflow out of a
+# private repo when the caller is public ("workflow was not found" with zero
+# jobs scheduled — this broke the whole fleet when the workflows briefly lived
+# in the private WYRE-AI/.github after the org migration). PR-time lint/test gating
 # is each repo's ci.yml concern; this workflow only runs the release path.
 # Caller jobs grant the token scopes the reusable jobs request (a reusable can
 # only reduce, never expand, caller-granted scope).
@@ -27,7 +31,7 @@ jobs:
     # existed in this repo's hand-rolled workflow and was dropped by the
     # centralization in #183, so every release from v2.30.0 on shipped with no
     # assets while the README still pointed users at the bundle (#244).
-    uses: WYRE-AI/.github/.github/workflows/mcp-server-release.yml@8c2360058e882a8afacfc4cebf840135789ef406
+    uses: WYRE-AI/reusable-workflows/.github/workflows/mcp-server-release.yml@2b0b056bd7544937e5cbd56cf2e1ff8a180a411f
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-ai/autotask-mcp
@@ -49,7 +53,7 @@ jobs:
   #   permissions:
   #     id-token: write
   #     contents: read
-  #   uses: WYRE-AI/.github/.github/workflows/mcp-server-deploy.yml@8c2360058e882a8afacfc4cebf840135789ef406
+  #   uses: WYRE-AI/reusable-workflows/.github/workflows/mcp-server-deploy.yml@2b0b056bd7544937e5cbd56cf2e1ff8a180a411f
   #   with:
   #     vendor-slug: autotask
   #     image-name: ghcr.io/wyre-ai/autotask-mcp


### PR DESCRIPTION
Public repos cannot call reusable workflows hosted in a private repo — GitHub fails the run with `workflow was not found` before any job is scheduled. The fleet's canonical `mcp-server-release.yml` moved into the private `WYRE-AI/.github` during the org migration, which broke `release.yml` here.

Same root cause and fix as WYRE-AI/datto-rmm-mcp#81: the reusable workflows now live in the public [`WYRE-AI/reusable-workflows`](https://github.com/WYRE-AI/reusable-workflows) (copied verbatim from `WYRE-AI/.github@8c23600`, audited — no secrets). `WYRE-AI/.github` stays private. This PR bumps the caller pin; the commented-out deploy block is repointed too so re-enabling it later doesn't resurrect the bug.

Found via a fleet-wide scan-mcp-repos sweep — confirmed the same symptom (0 jobs scheduled, "workflow file issue") hit this repo and WYRE-AI/nutanix-mcp (companion PR incoming). No deploy/publish behavior change — release path only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790999229&installation_model_id=431408&pr_number=272&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F272&signature=58f45e23c2a239bd863506fe429f6a28851323a850c75344089feb5b2b25c3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release and deployment automation to use the latest shared workflow configuration.
  * Improved workflow documentation to clarify hosting and visibility requirements for release automation.
  * No changes to exported functionality or end-user product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->