### PR TITLE
fix: update `createTimeEntry` to use correct endpoint

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -905,7 +905,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   // Time entry tools
   {
     name: 'autotask_create_time_entry',
-    description: 'Create a time entry in Autotask. Can be tied to a ticket, task, or project, OR created as "Regular Time" (no parent) for meetings, admin work, etc. For Regular Time, specify a category like "Internal Meeting", "Office Management", "Training", etc.',
+    description: 'Create a time entry in Autotask. Can be tied to a ticket or task, OR created as "Regular Time" (no parent) for meetings, admin work, etc. For Regular Time, specify a category like "Internal Meeting", "Office Management", "Training", etc.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -917,10 +917,6 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Task ID for the time entry (for project work, omit for Regular Time)'
         },
-        projectID: {
-          type: 'number',
-          description: 'Project ID for the time entry (omit for Regular Time)'
-        },
         resourceID: {
           type: 'number',
           description: 'Resource ID (user) logging the time. Can be omitted if resourceName is provided.'

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -651,29 +651,10 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Creating time entry:', timeEntry);
-
-      // Ticket-scoped
-      if (timeEntry.ticketID) {
-        const id = await http.childCreate('Tickets', timeEntry.ticketID, 'TimeEntries', timeEntry);
-        this.logger.info(`Time entry created with ID: ${id}`);
-        return id;
-      }
-      // Task-scoped
-      if (timeEntry.taskID) {
-        const id = await http.childCreate('Tasks', timeEntry.taskID, 'TimeEntries', timeEntry);
-        this.logger.info(`Time entry created with ID: ${id}`);
-        return id;
-      }
-      // Project-scoped
-      if (timeEntry.projectID) {
-        const id = await http.childCreate('Projects', timeEntry.projectID, 'TimeEntries', timeEntry);
-        this.logger.info(`Time entry created with ID: ${id}`);
-        return id;
-      }
-      // Regular (no parent — meetings, admin, etc.)
-      // Autotask accepts a POST /TimeEntries with no parent for regular entries.
+      
+      // Payload with a ticketID or taskID will be logged against that Ticker or Task, or as "regular time" otherwise
       const id = await http.create('TimeEntries', timeEntry);
-      this.logger.info(`Regular time entry created with ID: ${id}`);
+      this.logger.info(`Time entry created with ID: ${id}`);
       return id;
     } catch (error) {
       this.logger.error('Failed to create time entry:', error);


### PR DESCRIPTION
This PR updates `createTimeEntry` so it uses the correct API endpoint of `/TimeEntries` only.

Also updates the `autotask_create_time_entry` description to note that time entries can only be for a Task, Ticket or "regular" (not associated with a Task or Ticket).

As time entries cannot be logged against a Project the `projectID` property has also been removed from the list of properties for that tool.

Closes #277

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791420098&installation_model_id=431408&pr_number=278&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F278&signature=80ff926b0a617248657ecd11f312f82f8dfe8b23cf23114ea6e3784f316d5533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time entries are now created consistently through the standard time-entry workflow.
  * Time-entry associations are limited to supported tickets and tasks; project IDs are no longer accepted.
  * Existing Regular Time behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->