### PR TITLE
fix: add roleID for time entries

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -925,6 +925,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'string',
           description: 'Name of the resource/user (e.g., "Will Spence"). Will be resolved to a resourceID automatically. Use this instead of resourceID for convenience.'
         },
+        roleID: {
+          type: 'number',
+          description: 'Role ID associated with the time entry. Optional as this will default to ticketID.assignedResourceroleID or taskID.assignedResourceroleID for Ticket and Task time entries respectively and will be ignored for Regular Time entries. If the system setting "Allow users to modify Role when creating/editing time entries on tickets" is enabled this may be set to a different Role ID.'
+        },
         category: {
           type: 'string',
           description: 'Category name for Regular Time entries (e.g., "Internal Meeting", "Office Management", "Training", "Research", "HR/Recruiting", "Travel Time", "Holiday", "PTO"). Required for Regular Time entries (when neither ticketID nor taskID is specified).'

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -800,6 +800,24 @@ export class AutotaskToolHandler {
   }
 
   /**
+   * Resolve the roleID for a ticket- or task-scoped time entry from the
+   * parent's assignedResourceRoleID. Used by autotask_create_time_entry when
+   * the caller didn't supply an explicit roleID.
+   */
+  private async resolveParentRoleID(kind: 'Ticket' | 'Task', id: number): Promise<number> {
+    const parent = kind === 'Ticket'
+      ? await this.autotaskService.getTicket(id)
+      : await this.autotaskService.getTask(id);
+    if (parent === null) {
+      throw new Error(`No ${kind} found matching "${id}"`);
+    }
+    if (parent.assignedResourceRoleID === undefined) {
+      throw new Error(`No "assignedResourceRoleID" found for ${kind} "${id}" and no roleID provided`);
+    }
+    return parent.assignedResourceRoleID;
+  }
+
+  /**
    * Dispatch table: maps tool names to handler functions
    */
   private getDispatchTable(): Map<string, (args: any) => Promise<{ result: any; message: string }>> {
@@ -1002,25 +1020,9 @@ export class AutotaskToolHandler {
           // for non-regular time entries a roleID must be set
           // this defaults to ticketID.assignedResourceroleID or taskID.assignedResourceroleID but may be overridden
           if (!a.roleID) {
-            if (!a.taskID) {
-              const t = await s.getTicket(a.ticketID);
-              if (t === null) {
-                throw new Error(`No Ticket found matching "${a.ticketID}"`);
-              }
-              if (t.assignedResourceRoleID === undefined) {
-                throw new Error(`No "assignedResourceRoleID" found for Ticket "${a.ticketID}" and no roleID provided`);
-              }
-              a.roleID = t.assignedResourceRoleID;
-            } else {
-              const t = await s.getTask(a.taskID);
-              if (t === null) {
-                throw new Error(`No Task found matching "${a.taskID}"`);
-              }
-              if (t.assignedResourceRoleID === undefined) {
-                throw new Error(`No "assignedResourceRoleID" found for Task "${a.taskID}" and no roleID provided`);
-              }
-              a.roleID = t.assignedResourceRoleID;
-            }
+            a.roleID = a.taskID
+              ? await this.resolveParentRoleID('Task', a.taskID)
+              : await this.resolveParentRoleID('Ticket', a.ticketID);
           }
         }
         const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1022,8 +1022,9 @@ export class AutotaskToolHandler {
               a.roleID = t.assignedResourceID;
             }
           }
-          const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
-        }],
+        }
+        const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
+      }],
 
       // Projects
       ['autotask_search_projects', async (a) => {

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -998,6 +998,32 @@ export class AutotaskToolHandler {
             a.internalBillingCodeID = billingCode.id;
             delete a.category;
           }
+        } else {
+          // for non-regular time entries a roleID must be set
+          // this defaults to ticketID.assignedResourceroleID or taskID.assignedResourceroleID but may be overridden
+          if (!a.roleID) {
+            if (!a.taskID) {
+              const t = await s.getTicket(a.ticketID);
+              if (t === null) {
+                throw new Error(`No Ticket found matching "${a.ticketID}"`);
+              }
+              if (t.assignedResourceID === undefined) {
+                throw new Error(`No "assignedResourceID" found for Ticket "${a.ticketID}" and no roleID provided`);
+              }
+              a.roleID = t.assignedResourceID;
+            }
+          } else if (!a.ticketID) {
+            const t = await s.getTask(a.taskID);
+            if (t === null) {
+              throw new Error(`No Task found matching "${a.taskID}"`);
+            }
+            if (t.assignedResourceID === undefined) {
+              throw new Error(`No "assignedResourceID" found for Task "${a.taskID}" and no roleID provided`);
+            }
+            a.roleID = t.assignedResourceID;
+          } else {
+            throw new Error(`A taskID or ticketID must be provided for non-regular time entries`);
+          }
         }
         const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
       }],

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1011,20 +1011,19 @@ export class AutotaskToolHandler {
                 throw new Error(`No "assignedResourceID" found for Ticket "${a.ticketID}" and no roleID provided`);
               }
               a.roleID = t.assignedResourceID;
+            } else {
+              const t = await s.getTask(a.taskID);
+              if (t === null) {
+                throw new Error(`No Task found matching "${a.taskID}"`);
+              }
+              if (t.assignedResourceID === undefined) {
+                throw new Error(`No "assignedResourceID" found for Task "${a.taskID}" and no roleID provided`);
+              }
+              a.roleID = t.assignedResourceID;
             }
-          } else {
-            const t = await s.getTask(a.taskID);
-            if (t === null) {
-              throw new Error(`No Task found matching "${a.taskID}"`);
-            }
-            if (t.assignedResourceID === undefined) {
-              throw new Error(`No "assignedResourceID" found for Task "${a.taskID}" and no roleID provided`);
-            }
-            a.roleID = t.assignedResourceID;
           }
-        }
-        const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
-      }],
+          const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
+        }],
 
       // Projects
       ['autotask_search_projects', async (a) => {

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1007,19 +1007,19 @@ export class AutotaskToolHandler {
               if (t === null) {
                 throw new Error(`No Ticket found matching "${a.ticketID}"`);
               }
-              if (t.assignedResourceID === undefined) {
-                throw new Error(`No "assignedResourceID" found for Ticket "${a.ticketID}" and no roleID provided`);
+              if (t.assignedResourceRoleID === undefined) {
+                throw new Error(`No "assignedResourceRoleID" found for Ticket "${a.ticketID}" and no roleID provided`);
               }
-              a.roleID = t.assignedResourceID;
+              a.roleID = t.assignedResourceRoleID;
             } else {
               const t = await s.getTask(a.taskID);
               if (t === null) {
                 throw new Error(`No Task found matching "${a.taskID}"`);
               }
-              if (t.assignedResourceID === undefined) {
-                throw new Error(`No "assignedResourceID" found for Task "${a.taskID}" and no roleID provided`);
+              if (t.assignedResourceRoleID === undefined) {
+                throw new Error(`No "assignedResourceRoleID" found for Task "${a.taskID}" and no roleID provided`);
               }
-              a.roleID = t.assignedResourceID;
+              a.roleID = t.assignedResourceRoleID;
             }
           }
         }

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1012,7 +1012,7 @@ export class AutotaskToolHandler {
               }
               a.roleID = t.assignedResourceID;
             }
-          } else if (!a.ticketID) {
+          } else {
             const t = await s.getTask(a.taskID);
             if (t === null) {
               throw new Error(`No Task found matching "${a.taskID}"`);
@@ -1021,8 +1021,6 @@ export class AutotaskToolHandler {
               throw new Error(`No "assignedResourceID" found for Task "${a.taskID}" and no roleID provided`);
             }
             a.roleID = t.assignedResourceID;
-          } else {
-            throw new Error(`A taskID or ticketID must be provided for non-regular time entries`);
           }
         }
         const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -40,6 +40,7 @@ export interface AutotaskTicket {
   companyID?: number;
   contactID?: number;
   assignedResourceID?: number;
+  assignedResourceRoleID?: number;
   title?: string;
   description?: string;
   status?: number;

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -181,6 +181,7 @@ export interface AutotaskTask {
   title?: string;
   description?: string;
   assignedResourceID?: number;
+  assignedResourceRoleID?: number;
   status?: number;
   priority?: number;
   startDate?: string;

--- a/tests/create-time-entry-roleid.test.ts
+++ b/tests/create-time-entry-roleid.test.ts
@@ -1,0 +1,174 @@
+// Tests for autotask_create_time_entry auto-populating roleID on non-Regular
+// (ticket- or task-scoped) time entries: it defaults to the parent's
+// assignedResourceRoleID, may be overridden by an explicit roleID, and throws
+// an actionable error when neither the override nor the parent's role is
+// available.
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const logger = new Logger('error');
+
+const config: McpServerConfig = {
+  name: 'test-server',
+  version: '0.0.0',
+  autotask: {
+    username: 'user@example.com',
+    secret: 'secret',
+    integrationCode: 'integration-code',
+    apiUrl: 'https://webservices2.autotask.net/ATServicesRest/',
+  },
+};
+
+function makeHandler() {
+  const service = new AutotaskService(config, logger);
+  const getTicketSpy = jest.spyOn(service, 'getTicket');
+  const getTaskSpy = jest.spyOn(service, 'getTask');
+  const createSpy = jest.spyOn(service, 'createTimeEntry').mockResolvedValue(4242);
+  const handler = new AutotaskToolHandler(service, logger);
+  return { service, handler, getTicketSpy, getTaskSpy, createSpy };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('autotask_create_time_entry roleID defaulting', () => {
+  test('happy path (ticket-scoped): roleID defaults from ticket.assignedResourceRoleID', async () => {
+    const { handler, getTicketSpy, getTaskSpy, createSpy } = makeHandler();
+    getTicketSpy.mockResolvedValue({ id: 48231, assignedResourceRoleID: 7 } as any);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      ticketID: 48231,
+      resourceID: 12,
+      hoursWorked: 1.5,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(getTicketSpy).toHaveBeenCalledWith(48231);
+    expect(getTaskSpy).not.toHaveBeenCalled();
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ ticketID: 48231, roleID: 7 }));
+  });
+
+  test('happy path (task-scoped): roleID defaults from task.assignedResourceRoleID', async () => {
+    const { handler, getTicketSpy, getTaskSpy, createSpy } = makeHandler();
+    getTaskSpy.mockResolvedValue({ id: 777, assignedResourceRoleID: 9 } as any);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      taskID: 777,
+      resourceID: 12,
+      hoursWorked: 2,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(getTaskSpy).toHaveBeenCalledWith(777);
+    expect(getTicketSpy).not.toHaveBeenCalled();
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ taskID: 777, roleID: 9 }));
+  });
+
+  test('an explicit roleID overrides the lookup and skips it entirely', async () => {
+    const { handler, getTicketSpy, getTaskSpy, createSpy } = makeHandler();
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      ticketID: 48231,
+      resourceID: 12,
+      hoursWorked: 1.5,
+      roleID: 3,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(getTicketSpy).not.toHaveBeenCalled();
+    expect(getTaskSpy).not.toHaveBeenCalled();
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ ticketID: 48231, roleID: 3 }));
+  });
+
+  test('throws when the ticket has no assignedResourceRoleID and no roleID was provided', async () => {
+    const { handler, getTicketSpy, createSpy } = makeHandler();
+    getTicketSpy.mockResolvedValue({ id: 48231 } as any);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      ticketID: 48231,
+      resourceID: 12,
+      hoursWorked: 1.5,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/assignedResourceRoleID/);
+    expect(result.content[0].text).toContain('Ticket');
+    expect(result.content[0].text).toContain('48231');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test('throws when the task has no assignedResourceRoleID and no roleID was provided', async () => {
+    const { handler, getTaskSpy, createSpy } = makeHandler();
+    getTaskSpy.mockResolvedValue({ id: 777 } as any);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      taskID: 777,
+      resourceID: 12,
+      hoursWorked: 2,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/assignedResourceRoleID/);
+    expect(result.content[0].text).toContain('Task');
+    expect(result.content[0].text).toContain('777');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test('throws when the ticketID does not resolve to a ticket', async () => {
+    const { handler, getTicketSpy, createSpy } = makeHandler();
+    getTicketSpy.mockResolvedValue(null);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      ticketID: 99999,
+      resourceID: 12,
+      hoursWorked: 1,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No Ticket found matching');
+    expect(result.content[0].text).toContain('99999');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test('throws when the taskID does not resolve to a task', async () => {
+    const { handler, getTaskSpy, createSpy } = makeHandler();
+    getTaskSpy.mockResolvedValue(null);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      taskID: 99999,
+      resourceID: 12,
+      hoursWorked: 1,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No Task found matching');
+    expect(result.content[0].text).toContain('99999');
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test('Regular Time entries (no ticket/task) never trigger the roleID lookup', async () => {
+    const { handler, getTicketSpy, getTaskSpy, createSpy } = makeHandler();
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      resourceID: 12,
+      hoursWorked: 1,
+      internalBillingCodeID: 3,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(getTicketSpy).not.toHaveBeenCalled();
+    expect(getTaskSpy).not.toHaveBeenCalled();
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ resourceID: 12, hoursWorked: 1 }));
+    expect((createSpy.mock.calls[0][0] as any).roleID).toBeUndefined();
+  });
+});


### PR DESCRIPTION
I am unsure if this is the best approach, but this PR adds `roleID` as an additional field for the `autotask_create_time_entry` tool with `roleID` defaulting to `ticketID.assignedResourceroleID` for tickets or `taskID.assignedResourceroleID` for tasks.

For "regular" time entries no default is set as this is ignored by the Autotask API as per the below:

> On General Time Entry (not for task/tickets) the roleID will always be the default role for the resource, regardless of what value is provided.
> 
> For General Time Entry (not for task/tickets) the roleID defaults to the resource’s default roleID.
> 
> A Task Time Entry must have a valid roleID for the Resource and Task.
> 
> Ticket and Task Time Entries must include a roleID that is valid for the resourceID. The roleID must be the same as ticketID.assignedResourceroleID or taskID.assignedResourceroleID except when the system setting to "Allow users to modify Role when creating/editing time entries on tickets" is enabled.

https://autotask.net/help/DeveloperHelp/Content/APIs/REST/Entities/TimeEntriesEntity.htm

This does introduce some additional scenarios where calling `autotask_create_time_entry` may throw an error, such as  

This would close #280

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791442480&installation_model_id=431408&pr_number=281&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F281&signature=c7f4b3193f7795cb47d47e0fb774612227e75f0d40e07319f5102abfe430aef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Time-entry creation now supports an optional role ID.
  - For non-regular time entries, the role can default to the assigned role on the related ticket or task.
  - An explicitly provided role ID can override the default when permitted by system settings; regular time entries ignore this value.

- **Bug Fixes**
  - Improved error messages when the referenced ticket, task, or assigned role cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->