### PR TITLE
feat(docker): publish linux/arm64 alongside amd64 (#266)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,24 @@ jobs:
     # existed in this repo's hand-rolled workflow and was dropped by the
     # centralization in #183, so every release from v2.30.0 on shipped with no
     # assets while the README still pointed users at the bundle (#244).
-    uses: WYRE-AI/reusable-workflows/.github/workflows/mcp-server-release.yml@2b0b056bd7544937e5cbd56cf2e1ff8a180a411f
+    #
+    # Bumped to 697afaa for WYRE-AI/reusable-workflows#1, which adds the QEMU
+    # setup the `platforms:` input below needs. The input has always existed,
+    # but the docker job registered no binfmt handlers, so buildx could not
+    # emulate arm64 and a multi-arch request failed with "exec format error".
+    uses: WYRE-AI/reusable-workflows/.github/workflows/mcp-server-release.yml@697afaad1424f5db21c48f348f7baad9d0c9942e
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-ai/autotask-mcp
+      # Publish a multi-arch manifest so the image runs on ARM hosts — Apple
+      # Silicon, Raspberry Pi, AWS Graviton, Azure Ampere (issue #266).
+      #
+      # arm64 is built under QEMU emulation, which is slow but workable here
+      # because nothing in the Dockerfile compiles: dependencies are pure JS
+      # and install with `--ignore-scripts`. Keep it that way. In particular
+      # never add `npm install -g` — npm's self-update under emulation is the
+      # difference between a ~2 minute and a 60+ minute build.
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   # DEPLOY TEMPORARILY DISABLED (2026-08-25 org migration fleet wave).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,44 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Test Docker build
-        run: docker build --platform linux/amd64 --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -t autotask-mcp:test .
+  # Docker build check, one job per released architecture (issue #266).
+  #
+  # Split out of the Node matrix above, where it ran once per Node version and
+  # built the same image twice. Each architecture builds NATIVELY on its own
+  # runner rather than through QEMU: arm64 emulation is what turns a ~2 minute
+  # image build into a 30-60 minute one, and GitHub's arm64 runners are free
+  # for public repos. This gates the release build's `platforms:` at PR time,
+  # so a Dockerfile change that breaks one architecture fails here instead of
+  # after semantic-release has already cut a version.
+  docker:
+    name: Docker build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Build image for ${{ matrix.platform }}
+        run: docker build --platform ${{ matrix.platform }} --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -t autotask-mcp:test .
+
+      # The build alone proves it compiles; this proves the result actually
+      # starts on this architecture, which is the thing #266 asked for.
+      - name: Verify the image runs on ${{ matrix.platform }}
+        run: |
+          docker run --rm --platform ${{ matrix.platform }} \
+            --entrypoint node autotask-mcp:test \
+            -e "console.log('node ' + process.version + ' on ' + process.arch)"
 
   code-quality:
     name: Code Quality


### PR DESCRIPTION
Closes #266.

Releases shipped an amd64-only image, so the server couldn't run natively on Apple Silicon, Raspberry Pi, Graviton, or Ampere.

## Why this needed an upstream fix first

`mcp-server-release.yml` has always exposed a `platforms:` input, documented *"Comma-separated for multi-arch"*, and its digest verifier even normalises the platform-keyed `.Image` map that only a multi-arch build produces. But the docker job set up **buildx without QEMU**, and buildx cannot emulate a foreign architecture on its own. So the advertised multi-arch path was never reachable — setting `platforms:` here alone would have failed with `exec format error`.

Fixed in **WYRE-AI/reusable-workflows#1** (merged). This bumps the pin `2b0b056` → `697afaa` and opts in.

## Why emulated arm64 is fine here

Nothing in the Dockerfile compiles: production deps are `@modelcontextprotocol/*`, `winston`, `zod` — all pure JS — and install with `--ignore-scripts`. `node:26-alpine` publishes `linux/arm64/v8`.

The one real hazard is `npm install -g` under QEMU: npm's self-update is the difference between a ~2 minute and a 60+ minute build (`hudu-mcp` sat on a stuck build step for over an hour). This Dockerfile already avoids it deliberately, and I've left comments in both workflows so it stays that way.

## The PR-time check

The existing `Test Docker build` step lived inside the Node matrix, so it built the same image twice — once for Node 20.x, once for 22.x — and only ever for amd64.

It's now its own job, once per architecture, built **natively** on its own runner rather than under emulation (`ubuntu-24.04-arm` is free for public repos, and native is far faster than QEMU). Each also asserts the built image actually *starts* on that architecture, which is the thing #266 is really asking for:

```
docker run --rm --platform <arch> --entrypoint node autotask-mcp:test \
  -e "console.log('node ' + process.version + ' on ' + process.arch)"
```

Net effect: two builds before, two builds now, but covering two architectures instead of one Node version twice — and a Dockerfile change that breaks arm64 now fails on the PR rather than after semantic-release has already cut a version.

## Verification

The `Docker build (linux/arm64)` check on this PR is the pre-merge proof — it's the first native arm64 build of this image. I'll confirm the published multi-arch manifest carries a real `linux/arm64` entry after the release runs.

I couldn't test locally (no Docker on this machine), so the static checks I did run: both workflows parse as valid YAML, and `node:26-alpine` was confirmed to publish `linux/arm64/v8` via the registry manifest list.

https://claude.ai/code/session_01FbveqARUVfmyriwDU76F8Y

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791479249&installation_model_id=431408&pr_number=283&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F283&signature=e3e05a353b3b57ddc8e525a85098563e21fce78b6fe92d759e968533d64ce4a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now published for both amd64 and arm64 platforms, improving compatibility across supported environments.

* **Bug Fixes**
  * Release builds now use a pinned workflow version for more consistent image publishing.
  * Docker images are tested on each supported architecture and verified to start successfully before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->