### PR TITLE
feat(contracts): expose contract service lines, billed units, and a recurring-lines roll-up (read-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Added
+
+- **Contract service lines and billed units (read-only)**. Five tools close the gap between a contract header and what is actually invoiced:
+  - `autotask_search_contract_services` / `autotask_search_contract_service_bundles` — the service and bundle line items on a contract, with contract-specific unit price.
+  - `autotask_search_contract_service_units` / `autotask_search_contract_service_bundle_units` — the billed quantity and price per line over a date range, defaulting to rows active today.
+  - `autotask_get_contract_recurring_lines` — one-call roll-up per contract: every active line joined to the catalog (service name, vendor, billing period) and normalized to a monthly total, for MRR reporting and licensing reconciliation. Period types that cannot be resolved from the `Services.periodType` picklist are reported in `unresolvedPeriodTypes` instead of guessed.
+
 ### Changed
 
 - **Migrated from `@modelcontextprotocol/sdk` v1 to the v2 SDK (`@modelcontextprotocol/server` + `@modelcontextprotocol/node` 2.0.0-beta.5) with dual-era serving.** All three entrypoints now consume one shared per-request server factory (`AutotaskMcpServer.requestFactory()`), so the tool/resource/prompt surface can never drift between protocol eras:

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -2233,6 +2233,68 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     }
   },
   {
+    name: 'autotask_search_contract_services',
+    description: 'List the service line items on a contract (ContractServices): which catalog services are on the contract and at what contract-specific unit price. Read-only. Pair with autotask_search_contract_service_units for billed quantities, or use autotask_get_contract_recurring_lines for both in one call.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contractID: { type: 'number', description: 'Contract ID' },
+        pageSize: { type: 'number', description: 'Max rows (default 100, max 500)', minimum: 1, maximum: 500 }
+      },
+      required: ['contractID']
+    }
+  },
+  {
+    name: 'autotask_search_contract_service_units',
+    description: 'Billed unit rows for a contract (ContractServiceUnits): the quantity and contract price of each service line over a date range. By default returns only rows active today, i.e. what is currently being invoiced. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contractID: { type: 'number', description: 'Contract ID' },
+        activeOn: { type: 'string', description: 'ISO date (YYYY-MM-DD). Return rows whose start/end range covers this day. Default: today.' },
+        pageSize: { type: 'number', description: 'Max rows (default 200, max 500)', minimum: 1, maximum: 500 }
+      },
+      required: ['contractID']
+    }
+  },
+  {
+    name: 'autotask_search_contract_service_bundles',
+    description: 'List the service-bundle line items on a contract (ContractServiceBundles). Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contractID: { type: 'number', description: 'Contract ID' },
+        pageSize: { type: 'number', description: 'Max rows (default 100, max 500)', minimum: 1, maximum: 500 }
+      },
+      required: ['contractID']
+    }
+  },
+  {
+    name: 'autotask_search_contract_service_bundle_units',
+    description: 'Billed unit rows for bundle lines on a contract (ContractServiceBundleUnits), active on a given day (default today). Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contractID: { type: 'number', description: 'Contract ID' },
+        activeOn: { type: 'string', description: 'ISO date (YYYY-MM-DD). Default: today.' },
+        pageSize: { type: 'number', description: 'Max rows (default 200, max 500)', minimum: 1, maximum: 500 }
+      },
+      required: ['contractID']
+    }
+  },
+  {
+    name: 'autotask_get_contract_recurring_lines',
+    description: 'Recurring-revenue roll-up for one contract: every service and bundle line with units active on a day, joined to the catalog (service name, vendor, billing period) and normalized to a monthly total. Returns { contractID, contractName, companyID, companyName, activeOn, lines[], monthlyTotal, monthlyCost, unresolvedPeriodTypes[] }. Use this for MRR, licensing reconciliation, and "what does this client pay for" questions. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contractID: { type: 'number', description: 'Contract ID' },
+        activeOn: { type: 'string', description: 'ISO date (YYYY-MM-DD) the lines must be active on. Default: today.' }
+      },
+      required: ['contractID']
+    }
+  },
+  {
     name: 'autotask_list_expiring_contracts',
     description: 'List contracts whose end date falls within the next N days (expiring-contracts report). Optionally include already-expired contracts, and scope to one company or the whole org.',
     inputSchema: {
@@ -3179,7 +3241,7 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
   },
   financial: {
     description: 'Quotes, quote items, opportunities, invoices, and contracts',
-    tools: ['autotask_get_quote', 'autotask_search_quotes', 'autotask_create_quote', 'autotask_get_quote_item', 'autotask_search_quote_items', 'autotask_create_quote_item', 'autotask_update_quote_item', 'autotask_delete_quote_item', 'autotask_get_opportunity', 'autotask_search_opportunities', 'autotask_create_opportunity', 'autotask_search_invoices', 'autotask_search_contracts', 'autotask_get_contract', 'autotask_list_expiring_contracts', 'autotask_create_contract', 'autotask_create_contracts_bulk', 'autotask_update_contract', 'autotask_create_contract_service', 'autotask_update_contract_service']
+    tools: ['autotask_get_quote', 'autotask_search_quotes', 'autotask_create_quote', 'autotask_get_quote_item', 'autotask_search_quote_items', 'autotask_create_quote_item', 'autotask_update_quote_item', 'autotask_delete_quote_item', 'autotask_get_opportunity', 'autotask_search_opportunities', 'autotask_create_opportunity', 'autotask_search_invoices', 'autotask_search_contracts', 'autotask_get_contract', 'autotask_list_expiring_contracts', 'autotask_search_contract_services', 'autotask_search_contract_service_units', 'autotask_search_contract_service_bundles', 'autotask_search_contract_service_bundle_units', 'autotask_get_contract_recurring_lines', 'autotask_create_contract', 'autotask_create_contracts_bulk', 'autotask_update_contract', 'autotask_create_contract_service', 'autotask_update_contract_service']
   },
   products_and_services: {
     description: 'Products, services, and service bundles catalog',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1084,6 +1084,26 @@ export class AutotaskToolHandler {
       ['autotask_get_contract', async (a) => {
         const r = await s.getContract(a.id); return { result: r, message: `Retrieved contract ${a.id}` };
       }],
+      ['autotask_search_contract_services', async (a) => {
+        const r = await s.searchContractServices({ contractID: a.contractID, pageSize: a.pageSize });
+        return { result: r, message: `Found ${r.length} service lines on contract ${a.contractID}` };
+      }],
+      ['autotask_search_contract_service_units', async (a) => {
+        const r = await s.searchContractServiceUnits({ contractID: a.contractID, activeOn: a.activeOn, pageSize: a.pageSize });
+        return { result: r, message: `Found ${r.length} unit rows on contract ${a.contractID}${a.activeOn ? ` active on ${a.activeOn}` : ' active today'}` };
+      }],
+      ['autotask_search_contract_service_bundles', async (a) => {
+        const r = await s.searchContractServiceBundles({ contractID: a.contractID, pageSize: a.pageSize });
+        return { result: r, message: `Found ${r.length} bundle lines on contract ${a.contractID}` };
+      }],
+      ['autotask_search_contract_service_bundle_units', async (a) => {
+        const r = await s.searchContractServiceBundleUnits({ contractID: a.contractID, activeOn: a.activeOn, pageSize: a.pageSize });
+        return { result: r, message: `Found ${r.length} bundle unit rows on contract ${a.contractID}` };
+      }],
+      ['autotask_get_contract_recurring_lines', async (a) => {
+        const r = await s.getContractRecurringLines({ contractID: a.contractID, activeOn: a.activeOn });
+        return { result: r, message: `${r.lines.length} recurring lines on contract ${a.contractID}, $${r.monthlyTotal.toFixed(2)}/month as of ${r.activeOn}` };
+      }],
       ['autotask_list_expiring_contracts', async (a) => {
         const r = await s.listExpiringContracts(a);
         return { result: r, message: `Found ${r.length} contracts with end dates within ${a.daysAhead ?? 60} days` };

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -1262,18 +1262,29 @@ export class AutotaskService {
   }
 
   private periodLabelCache: Map<number, string> | null = null;
+  /**
+   * Services.periodType labels, cached for the process.
+   *
+   * Only a successful, non-empty load is cached, and a failure propagates. An
+   * earlier version cached the map outside the try and swallowed the error: a
+   * single failed getFieldInfo (a 429 is realistic here) left an empty map
+   * cached for the process lifetime, monthlyFactor then returned null for
+   * every period type, `factor ?? 1` billed yearly lines as monthly, and the
+   * contract total overstated by up to 12x. Without the picklist there is no
+   * correct monthly figure to return, so this fails loudly rather than
+   * quietly producing wrong money.
+   */
   private async servicePeriodLabels(): Promise<Map<number, string>> {
     if (this.periodLabelCache) return this.periodLabelCache;
     const map = new Map<number, string>();
-    try {
-      const fields = await this.getFieldInfo('Services');
-      const pt = fields.find(f => f.name === 'periodType');
-      for (const pv of pt?.picklistValues || []) {
-        const v = Number((pv as any).value);
-        if (!Number.isNaN(v)) map.set(v, String((pv as any).label ?? ''));
-      }
-    } catch (error) {
-      this.logger.warn('Could not load Services.periodType picklist; monthly normalization will be skipped', error);
+    const fields = await this.getFieldInfo('Services');
+    const pt = fields.find(f => f.name === 'periodType');
+    for (const pv of pt?.picklistValues || []) {
+      const v = Number((pv as any).value);
+      if (!Number.isNaN(v)) map.set(v, String((pv as any).label ?? ''));
+    }
+    if (map.size === 0) {
+      throw new Error('Services.periodType picklist came back empty; cannot normalize contract lines to a monthly figure');
     }
     this.periodLabelCache = map;
     return map;

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -1178,7 +1178,7 @@ export class AutotaskService {
       u: AutotaskContractServiceUnit | AutotaskContractServiceBundleUnit,
       line: { id?: number; unitPrice?: number; unitCost?: number; invoiceDescription?: string; internalDescription?: string } | undefined,
       cat: { name?: string; unitPrice?: number; unitCost?: number; periodType?: number; vendorCompanyID?: number } | undefined,
-      ids: { serviceID?: number; serviceBundleID?: number; lineID: number | undefined },
+      ids: { serviceID?: number | undefined; serviceBundleID?: number | undefined; lineID: number | undefined },
     ): AutotaskContractRecurringLine => {
       const units = Number(u.units ?? 0);
       const catalogRate = firstPositive(line?.unitPrice, cat?.unitPrice);

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -70,6 +70,40 @@ function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+function uniqueNumbers(values: Array<number | undefined | null>): number[] {
+  return Array.from(new Set(values.filter((v): v is number => typeof v === 'number' && !Number.isNaN(v))));
+}
+
+/** First value that is a non-empty string (`??` does not skip ""). */
+function firstNonEmpty(...values: Array<string | undefined | null>): string | undefined {
+  for (const v of values) if (typeof v === 'string' && v.trim() !== '') return v;
+  return undefined;
+}
+
+/** First value that is a positive number (`??` does not skip 0). */
+function firstPositive(...values: Array<number | undefined | null>): number | undefined {
+  for (const v of values) if (typeof v === 'number' && v > 0) return v;
+  return undefined;
+}
+
+/**
+ * Decide whether a ContractServiceUnits.price is the extended line amount or a
+ * per-unit rate by comparing it with the catalog rate. Extended is the observed
+ * default on live tenants; per-unit is accepted only when price itself matches
+ * the catalog and price/units does not.
+ */
+function classifyPriceBasis(price: number, units: number, catalogRate: number | undefined): 'extended' | 'per-unit' | 'assumed-extended' {
+  if (catalogRate == null || catalogRate <= 0 || units <= 0) return 'assumed-extended';
+  const close = (a: number, b: number) => Math.abs(a - b) <= Math.max(0.011, b * 0.005);
+  if (close(price / units, catalogRate)) return 'extended';
+  if (units > 1 && close(price, catalogRate)) return 'per-unit';
+  return 'assumed-extended';
+}
+
 function pushEq(filters: QueryFilter[], field: string, value: unknown): void {
   if (value !== undefined) {
     filters.push({ op: 'eq', field, value });
@@ -1082,18 +1116,27 @@ export class AutotaskService {
    * One call per contract for recurring-revenue reporting: every service and
    * bundle line with units active on `activeOn`, joined to the catalog for
    * names, vendors and billing period, and normalized to a monthly total.
-   * Lines whose period type cannot be resolved keep periodTotal as the monthly
-   * figure and are listed in `unresolvedPeriodTypes` rather than being guessed.
+   *
+   * Price basis. On live tenants `ContractServiceUnits.price` (and `.cost`) is
+   * the EXTENDED line amount for the period, not a per-unit rate: AIC's
+   * Business Premium row is units 11, price 254.10, catalog unitPrice 23.10.
+   * Each line is therefore checked against the catalog: if price/units matches
+   * the catalog rate the row is treated as extended (the expected case); if
+   * price itself matches the catalog rate the row is treated as per-unit; with
+   * no catalog match the row defaults to extended and says so in `priceBasis`.
+   *
+   * Catalog and vendor lookups run sequentially and are cached on the service
+   * instance; a rate-limit or auth error surfaces instead of degrading into
+   * rows with blank names. Lines whose period type cannot be resolved keep the
+   * period total as the monthly figure and appear in `unresolvedPeriodTypes`.
    */
   async getContractRecurringLines(options: { contractID: number; activeOn?: string }): Promise<AutotaskContractRecurringLines> {
     const activeOn = options.activeOn || new Date().toISOString().slice(0, 10);
-    const [contract, serviceLines, serviceUnits, bundleLines, bundleUnits] = await Promise.all([
-      this.getContract(options.contractID),
-      this.searchContractServices({ contractID: options.contractID, pageSize: 500 }),
-      this.searchContractServiceUnits({ contractID: options.contractID, activeOn, pageSize: 500 }),
-      this.searchContractServiceBundles({ contractID: options.contractID, pageSize: 500 }).catch(() => [] as AutotaskContractServiceBundle[]),
-      this.searchContractServiceBundleUnits({ contractID: options.contractID, activeOn, pageSize: 500 }).catch(() => [] as AutotaskContractServiceBundleUnit[]),
-    ]);
+    const contract = await this.getContract(options.contractID);
+    const serviceLines = await this.searchContractServices({ contractID: options.contractID, pageSize: 500 });
+    const serviceUnits = await this.searchContractServiceUnits({ contractID: options.contractID, activeOn, pageSize: 500 });
+    const bundleLines = await this.searchContractServiceBundles({ contractID: options.contractID, pageSize: 500 });
+    const bundleUnits = await this.searchContractServiceBundleUnits({ contractID: options.contractID, activeOn, pageSize: 500 });
 
     const periodLabels = await this.servicePeriodLabels();
     const unresolved = new Set<number>();
@@ -1104,27 +1147,19 @@ export class AutotaskService {
     const bundleById = new Map<number, AutotaskContractServiceBundle>();
     for (const l of bundleLines) if (l.id != null) bundleById.set(l.id, l);
 
-    const serviceIDs = Array.from(new Set(serviceUnits
-      .map(u => u.serviceID ?? serviceById.get(u.contractServiceID as number)?.serviceID)
-      .filter((x): x is number => x != null)));
-    const bundleIDs = Array.from(new Set(bundleUnits
-      .map(u => u.serviceBundleID ?? bundleById.get(u.contractServiceBundleID as number)?.serviceBundleID)
-      .filter((x): x is number => x != null)));
-
-    const catalog = new Map<number, any>();
-    await Promise.all(serviceIDs.map(async id => {
-      try { const svc = await this.getService(id); if (svc) catalog.set(id, svc); } catch { /* leave unresolved */ }
-    }));
-    const bundles = new Map<number, any>();
-    await Promise.all(bundleIDs.map(async id => {
-      try { const b = await this.getServiceBundle(id); if (b) bundles.set(id, b); } catch { /* leave unresolved */ }
-    }));
-    const vendorIDs = Array.from(new Set(Array.from(catalog.values())
-      .map(c => c.vendorCompanyID).filter((x): x is number => x != null)));
-    const vendors = new Map<number, string>();
-    await Promise.all(vendorIDs.map(async id => {
-      try { const c = await this.getCompany(id); if (c?.companyName) vendors.set(id, c.companyName); } catch { /* optional */ }
-    }));
+    // Sequential, cached lookups. No swallowed errors: a 429 or 401 here must be seen.
+    const serviceIDs = uniqueNumbers(serviceUnits.map(u => u.serviceID ?? serviceById.get(u.contractServiceID as number)?.serviceID));
+    const bundleIDs = uniqueNumbers(bundleUnits.map(u => u.serviceBundleID ?? bundleById.get(u.contractServiceBundleID as number)?.serviceBundleID));
+    for (const id of serviceIDs) {
+      if (!this.serviceCatalogCache.has(id)) this.serviceCatalogCache.set(id, await this.getService(id));
+    }
+    for (const id of bundleIDs) {
+      if (!this.bundleCatalogCache.has(id)) this.bundleCatalogCache.set(id, await this.getServiceBundle(id));
+    }
+    const vendorIDs = uniqueNumbers(serviceIDs.map(id => this.serviceCatalogCache.get(id)?.vendorCompanyID));
+    for (const id of vendorIDs) {
+      if (!this.vendorNameCache.has(id)) this.vendorNameCache.set(id, (await this.getCompany(id))?.companyName ?? undefined);
+    }
 
     const monthlyFactor = (periodType?: number): number | null => {
       if (periodType == null) return null;
@@ -1138,59 +1173,66 @@ export class AutotaskService {
       return null;
     };
 
+    const build = (
+      source: 'service' | 'bundle',
+      u: AutotaskContractServiceUnit | AutotaskContractServiceBundleUnit,
+      line: { id?: number; unitPrice?: number; unitCost?: number; invoiceDescription?: string; internalDescription?: string } | undefined,
+      cat: { name?: string; unitPrice?: number; unitCost?: number; periodType?: number; vendorCompanyID?: number } | undefined,
+      ids: { serviceID?: number; serviceBundleID?: number; lineID: number | undefined },
+    ): AutotaskContractRecurringLine => {
+      const units = Number(u.units ?? 0);
+      const catalogRate = firstPositive(line?.unitPrice, cat?.unitPrice);
+      const basis = classifyPriceBasis(Number(u.price ?? 0), units, catalogRate);
+      const periodTotal = basis === 'per-unit' ? round2(units * Number(u.price ?? 0)) : round2(Number(u.price ?? 0));
+      const unitPrice = units > 0 ? round4(periodTotal / units) : Number(u.price ?? 0);
+      const rawCost = Number(u.cost ?? 0);
+      const catalogCost = firstPositive(line?.unitCost, cat?.unitCost);
+      // Cost follows the same basis as price when present; otherwise fall back to the catalog rate.
+      const unitCost = rawCost > 0
+        ? (basis === 'per-unit' ? rawCost : (units > 0 ? round4(rawCost / units) : rawCost))
+        : (catalogCost ?? 0);
+      const factor = monthlyFactor(cat?.periodType);
+      if (factor === null && cat?.periodType != null) unresolved.add(cat.periodType);
+      const fallbackName = source === 'service' ? `Service ${ids.serviceID}` : `Bundle ${ids.serviceBundleID}`;
+      return {
+        source,
+        lineID: ids.lineID,
+        ...(ids.serviceID != null ? { serviceID: ids.serviceID } : {}),
+        ...(ids.serviceBundleID != null ? { serviceBundleID: ids.serviceBundleID } : {}),
+        name: firstNonEmpty(cat?.name, line?.invoiceDescription, line?.internalDescription) ?? fallbackName,
+        vendorCompanyID: cat?.vendorCompanyID,
+        vendorName: cat?.vendorCompanyID != null ? this.vendorNameCache.get(cat.vendorCompanyID) : undefined,
+        periodType: cat?.periodType,
+        periodLabel: cat?.periodType != null ? periodLabels.get(cat.periodType) : undefined,
+        priceBasis: basis,
+        units,
+        unitPrice,
+        unitCost,
+        periodTotal,
+        monthlyTotal: round2(periodTotal * (factor ?? 1)),
+        monthlyCost: round2(units * unitCost * (factor ?? 1)),
+        startDate: u.startDate,
+        endDate: u.endDate,
+      };
+    };
+
     for (const u of serviceUnits) {
       const line = serviceById.get(u.contractServiceID as number);
       const serviceID = u.serviceID ?? line?.serviceID;
-      const svc = serviceID != null ? catalog.get(serviceID) : undefined;
-      const units = Number(u.units ?? 0);
-      const unitPrice = Number(u.price ?? line?.unitPrice ?? svc?.unitPrice ?? 0);
-      const unitCost = Number(u.cost ?? line?.unitCost ?? svc?.unitCost ?? 0);
-      const factor = monthlyFactor(svc?.periodType);
-      if (factor === null && svc?.periodType != null) unresolved.add(svc.periodType);
-      const periodTotal = round2(units * unitPrice);
-      lines.push({
-        source: 'service',
-        lineID: line?.id ?? u.contractServiceID,
-        serviceID,
-        name: svc?.name ?? line?.invoiceDescription ?? `Service ${serviceID}`,
-        vendorCompanyID: svc?.vendorCompanyID,
-        vendorName: svc?.vendorCompanyID != null ? vendors.get(svc.vendorCompanyID) : undefined,
-        periodType: svc?.periodType,
-        periodLabel: svc?.periodType != null ? periodLabels.get(svc.periodType) : undefined,
-        units, unitPrice, unitCost, periodTotal,
-        monthlyTotal: round2(periodTotal * (factor ?? 1)),
-        monthlyCost: round2(units * unitCost * (factor ?? 1)),
-        startDate: u.startDate, endDate: u.endDate,
-      });
+      const cat = serviceID != null ? this.serviceCatalogCache.get(serviceID) ?? undefined : undefined;
+      lines.push(build('service', u, line, cat, { serviceID, lineID: line?.id ?? u.contractServiceID }));
     }
     for (const u of bundleUnits) {
       const line = bundleById.get(u.contractServiceBundleID as number);
       const serviceBundleID = u.serviceBundleID ?? line?.serviceBundleID;
-      const b = serviceBundleID != null ? bundles.get(serviceBundleID) : undefined;
-      const units = Number(u.units ?? 0);
-      const unitPrice = Number(u.price ?? line?.unitPrice ?? b?.unitPrice ?? 0);
-      const unitCost = Number(u.cost ?? line?.unitCost ?? b?.unitCost ?? 0);
-      const factor = monthlyFactor(b?.periodType);
-      if (factor === null && b?.periodType != null) unresolved.add(b.periodType);
-      const periodTotal = round2(units * unitPrice);
-      lines.push({
-        source: 'bundle',
-        lineID: line?.id ?? u.contractServiceBundleID,
-        serviceBundleID,
-        name: b?.name ?? line?.invoiceDescription ?? `Bundle ${serviceBundleID}`,
-        periodType: b?.periodType,
-        periodLabel: b?.periodType != null ? periodLabels.get(b.periodType) : undefined,
-        units, unitPrice, unitCost, periodTotal,
-        monthlyTotal: round2(periodTotal * (factor ?? 1)),
-        monthlyCost: round2(units * unitCost * (factor ?? 1)),
-        startDate: u.startDate, endDate: u.endDate,
-      });
+      const cat = serviceBundleID != null ? this.bundleCatalogCache.get(serviceBundleID) ?? undefined : undefined;
+      lines.push(build('bundle', u, line, cat, { serviceBundleID, lineID: line?.id ?? u.contractServiceBundleID }));
     }
 
     lines.sort((a, b) => b.monthlyTotal - a.monthlyTotal || a.name.localeCompare(b.name));
     let companyName: string | undefined;
     if (contract?.companyID != null) {
-      try { companyName = (await this.getCompany(contract.companyID))?.companyName; } catch { /* optional */ }
+      companyName = (await this.getCompany(contract.companyID))?.companyName ?? undefined;
     }
     return {
       contractID: options.contractID,
@@ -1202,8 +1244,13 @@ export class AutotaskService {
       monthlyTotal: round2(lines.reduce((a, l) => a + l.monthlyTotal, 0)),
       monthlyCost: round2(lines.reduce((a, l) => a + l.monthlyCost, 0)),
       unresolvedPeriodTypes: Array.from(unresolved).sort((a, b) => a - b),
+      assumedExtendedLines: lines.filter(l => l.priceBasis === 'assumed-extended').length,
     };
   }
+
+  private serviceCatalogCache = new Map<number, any>();
+  private bundleCatalogCache = new Map<number, any>();
+  private vendorNameCache = new Map<number, string | undefined>();
 
   private unitDateFilters(contractID: number, activeOn?: string): QueryFilter[] {
     const day = activeOn || new Date().toISOString().slice(0, 10);

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -9,6 +9,12 @@
 import { resolveAutotaskApiUrl } from '../utils/config';
 import { AutotaskHttpClient, QueryFilter } from './autotask-http';
 import {
+  AutotaskContractService,
+  AutotaskContractServiceUnit,
+  AutotaskContractServiceBundle,
+  AutotaskContractServiceBundleUnit,
+  AutotaskContractRecurringLine,
+  AutotaskContractRecurringLines,
   AutotaskCompany,
   AutotaskContact,
   AutotaskTicket,
@@ -60,6 +66,10 @@ export const MATCH_ALL: QueryFilter[] = [{ op: 'gte', field: 'id', value: 0 }];
  * `if (options.X !== undefined) filters.push({ op: 'eq', field: 'X', value: options.X })`
  * pattern that was previously duplicated across every search method.
  */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
 function pushEq(filters: QueryFilter[], field: string, value: unknown): void {
   if (value !== undefined) {
     filters.push({ op: 'eq', field, value });
@@ -1006,6 +1016,220 @@ export class AutotaskService {
       this.logger.error('Failed to search contracts:', error);
       throw error;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Contract service lines and billed units (read-only)
+  // ---------------------------------------------------------------------------
+
+  /** Service lines on a contract (ContractServices). */
+  async searchContractServices(options: { contractID: number; pageSize?: number }): Promise<AutotaskContractService[]> {
+    const http = await this.ensureClient();
+    try {
+      const filters: QueryFilter[] = [{ op: 'eq', field: 'contractID', value: options.contractID }];
+      const pageSize = Math.min(options.pageSize || 100, 500);
+      return await http.query<AutotaskContractService>('ContractServices', filters, { maxRecords: pageSize });
+    } catch (error) {
+      this.logger.error(`Failed to search contract services for contract ${options.contractID}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Billed unit rows for a contract (ContractServiceUnits). With `activeOn`
+   * (ISO date, default today) only rows whose date range covers that day are
+   * returned, which is the quantity currently being invoiced.
+   */
+  async searchContractServiceUnits(options: { contractID: number; activeOn?: string; pageSize?: number }): Promise<AutotaskContractServiceUnit[]> {
+    const http = await this.ensureClient();
+    try {
+      const filters = this.unitDateFilters(options.contractID, options.activeOn);
+      const pageSize = Math.min(options.pageSize || 200, 500);
+      return await http.query<AutotaskContractServiceUnit>('ContractServiceUnits', filters, { maxRecords: pageSize });
+    } catch (error) {
+      this.logger.error(`Failed to search contract service units for contract ${options.contractID}:`, error);
+      throw error;
+    }
+  }
+
+  /** Service-bundle lines on a contract (ContractServiceBundles). */
+  async searchContractServiceBundles(options: { contractID: number; pageSize?: number }): Promise<AutotaskContractServiceBundle[]> {
+    const http = await this.ensureClient();
+    try {
+      const filters: QueryFilter[] = [{ op: 'eq', field: 'contractID', value: options.contractID }];
+      const pageSize = Math.min(options.pageSize || 100, 500);
+      return await http.query<AutotaskContractServiceBundle>('ContractServiceBundles', filters, { maxRecords: pageSize });
+    } catch (error) {
+      this.logger.error(`Failed to search contract service bundles for contract ${options.contractID}:`, error);
+      throw error;
+    }
+  }
+
+  /** Billed unit rows for bundle lines (ContractServiceBundleUnits), same date semantics as service units. */
+  async searchContractServiceBundleUnits(options: { contractID: number; activeOn?: string; pageSize?: number }): Promise<AutotaskContractServiceBundleUnit[]> {
+    const http = await this.ensureClient();
+    try {
+      const filters = this.unitDateFilters(options.contractID, options.activeOn);
+      const pageSize = Math.min(options.pageSize || 200, 500);
+      return await http.query<AutotaskContractServiceBundleUnit>('ContractServiceBundleUnits', filters, { maxRecords: pageSize });
+    } catch (error) {
+      this.logger.error(`Failed to search contract service bundle units for contract ${options.contractID}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * One call per contract for recurring-revenue reporting: every service and
+   * bundle line with units active on `activeOn`, joined to the catalog for
+   * names, vendors and billing period, and normalized to a monthly total.
+   * Lines whose period type cannot be resolved keep periodTotal as the monthly
+   * figure and are listed in `unresolvedPeriodTypes` rather than being guessed.
+   */
+  async getContractRecurringLines(options: { contractID: number; activeOn?: string }): Promise<AutotaskContractRecurringLines> {
+    const activeOn = options.activeOn || new Date().toISOString().slice(0, 10);
+    const [contract, serviceLines, serviceUnits, bundleLines, bundleUnits] = await Promise.all([
+      this.getContract(options.contractID),
+      this.searchContractServices({ contractID: options.contractID, pageSize: 500 }),
+      this.searchContractServiceUnits({ contractID: options.contractID, activeOn, pageSize: 500 }),
+      this.searchContractServiceBundles({ contractID: options.contractID, pageSize: 500 }).catch(() => [] as AutotaskContractServiceBundle[]),
+      this.searchContractServiceBundleUnits({ contractID: options.contractID, activeOn, pageSize: 500 }).catch(() => [] as AutotaskContractServiceBundleUnit[]),
+    ]);
+
+    const periodLabels = await this.servicePeriodLabels();
+    const unresolved = new Set<number>();
+    const lines: AutotaskContractRecurringLine[] = [];
+
+    const serviceById = new Map<number, AutotaskContractService>();
+    for (const l of serviceLines) if (l.id != null) serviceById.set(l.id, l);
+    const bundleById = new Map<number, AutotaskContractServiceBundle>();
+    for (const l of bundleLines) if (l.id != null) bundleById.set(l.id, l);
+
+    const serviceIDs = Array.from(new Set(serviceUnits
+      .map(u => u.serviceID ?? serviceById.get(u.contractServiceID as number)?.serviceID)
+      .filter((x): x is number => x != null)));
+    const bundleIDs = Array.from(new Set(bundleUnits
+      .map(u => u.serviceBundleID ?? bundleById.get(u.contractServiceBundleID as number)?.serviceBundleID)
+      .filter((x): x is number => x != null)));
+
+    const catalog = new Map<number, any>();
+    await Promise.all(serviceIDs.map(async id => {
+      try { const svc = await this.getService(id); if (svc) catalog.set(id, svc); } catch { /* leave unresolved */ }
+    }));
+    const bundles = new Map<number, any>();
+    await Promise.all(bundleIDs.map(async id => {
+      try { const b = await this.getServiceBundle(id); if (b) bundles.set(id, b); } catch { /* leave unresolved */ }
+    }));
+    const vendorIDs = Array.from(new Set(Array.from(catalog.values())
+      .map(c => c.vendorCompanyID).filter((x): x is number => x != null)));
+    const vendors = new Map<number, string>();
+    await Promise.all(vendorIDs.map(async id => {
+      try { const c = await this.getCompany(id); if (c?.companyName) vendors.set(id, c.companyName); } catch { /* optional */ }
+    }));
+
+    const monthlyFactor = (periodType?: number): number | null => {
+      if (periodType == null) return null;
+      const label = (periodLabels.get(periodType) || '').toLowerCase();
+      if (/semi/.test(label)) return 1 / 6;
+      if (/quarter/.test(label)) return 1 / 3;
+      if (/annual|year/.test(label)) return 1 / 12;
+      if (/month/.test(label)) return 1;
+      if (/week/.test(label)) return 52 / 12;
+      if (/one[- ]?time/.test(label)) return 0;
+      return null;
+    };
+
+    for (const u of serviceUnits) {
+      const line = serviceById.get(u.contractServiceID as number);
+      const serviceID = u.serviceID ?? line?.serviceID;
+      const svc = serviceID != null ? catalog.get(serviceID) : undefined;
+      const units = Number(u.units ?? 0);
+      const unitPrice = Number(u.price ?? line?.unitPrice ?? svc?.unitPrice ?? 0);
+      const unitCost = Number(u.cost ?? line?.unitCost ?? svc?.unitCost ?? 0);
+      const factor = monthlyFactor(svc?.periodType);
+      if (factor === null && svc?.periodType != null) unresolved.add(svc.periodType);
+      const periodTotal = round2(units * unitPrice);
+      lines.push({
+        source: 'service',
+        lineID: line?.id ?? u.contractServiceID,
+        serviceID,
+        name: svc?.name ?? line?.invoiceDescription ?? `Service ${serviceID}`,
+        vendorCompanyID: svc?.vendorCompanyID,
+        vendorName: svc?.vendorCompanyID != null ? vendors.get(svc.vendorCompanyID) : undefined,
+        periodType: svc?.periodType,
+        periodLabel: svc?.periodType != null ? periodLabels.get(svc.periodType) : undefined,
+        units, unitPrice, unitCost, periodTotal,
+        monthlyTotal: round2(periodTotal * (factor ?? 1)),
+        monthlyCost: round2(units * unitCost * (factor ?? 1)),
+        startDate: u.startDate, endDate: u.endDate,
+      });
+    }
+    for (const u of bundleUnits) {
+      const line = bundleById.get(u.contractServiceBundleID as number);
+      const serviceBundleID = u.serviceBundleID ?? line?.serviceBundleID;
+      const b = serviceBundleID != null ? bundles.get(serviceBundleID) : undefined;
+      const units = Number(u.units ?? 0);
+      const unitPrice = Number(u.price ?? line?.unitPrice ?? b?.unitPrice ?? 0);
+      const unitCost = Number(u.cost ?? line?.unitCost ?? b?.unitCost ?? 0);
+      const factor = monthlyFactor(b?.periodType);
+      if (factor === null && b?.periodType != null) unresolved.add(b.periodType);
+      const periodTotal = round2(units * unitPrice);
+      lines.push({
+        source: 'bundle',
+        lineID: line?.id ?? u.contractServiceBundleID,
+        serviceBundleID,
+        name: b?.name ?? line?.invoiceDescription ?? `Bundle ${serviceBundleID}`,
+        periodType: b?.periodType,
+        periodLabel: b?.periodType != null ? periodLabels.get(b.periodType) : undefined,
+        units, unitPrice, unitCost, periodTotal,
+        monthlyTotal: round2(periodTotal * (factor ?? 1)),
+        monthlyCost: round2(units * unitCost * (factor ?? 1)),
+        startDate: u.startDate, endDate: u.endDate,
+      });
+    }
+
+    lines.sort((a, b) => b.monthlyTotal - a.monthlyTotal || a.name.localeCompare(b.name));
+    let companyName: string | undefined;
+    if (contract?.companyID != null) {
+      try { companyName = (await this.getCompany(contract.companyID))?.companyName; } catch { /* optional */ }
+    }
+    return {
+      contractID: options.contractID,
+      contractName: contract?.contractName,
+      companyID: contract?.companyID,
+      companyName,
+      activeOn,
+      lines,
+      monthlyTotal: round2(lines.reduce((a, l) => a + l.monthlyTotal, 0)),
+      monthlyCost: round2(lines.reduce((a, l) => a + l.monthlyCost, 0)),
+      unresolvedPeriodTypes: Array.from(unresolved).sort((a, b) => a - b),
+    };
+  }
+
+  private unitDateFilters(contractID: number, activeOn?: string): QueryFilter[] {
+    const day = activeOn || new Date().toISOString().slice(0, 10);
+    return [
+      { op: 'eq', field: 'contractID', value: contractID },
+      { op: 'lte', field: 'startDate', value: `${day}T23:59:59` },
+      { op: 'gte', field: 'endDate', value: `${day}T00:00:00` },
+    ];
+  }
+
+  private periodLabelCache: Map<number, string> | null = null;
+  private async servicePeriodLabels(): Promise<Map<number, string>> {
+    if (this.periodLabelCache) return this.periodLabelCache;
+    const map = new Map<number, string>();
+    try {
+      const fields = await this.getFieldInfo('Services');
+      const pt = fields.find(f => f.name === 'periodType');
+      for (const pv of pt?.picklistValues || []) {
+        const v = Number((pv as any).value);
+        if (!Number.isNaN(v)) map.set(v, String((pv as any).label ?? ''));
+      }
+    } catch (error) {
+      this.logger.warn('Could not load Services.periodType picklist; monthly normalization will be skipped', error);
+    }
+    this.periodLabelCache = map;
+    return map;
   }
 
   /**

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -227,6 +227,8 @@ export interface AutotaskContractRecurringLine {
   vendorName?: string | undefined;
   periodType?: number | undefined;
   periodLabel?: string | undefined;
+  /** How ContractServiceUnits.price was read: extended line amount (observed default), per-unit rate, or assumed extended with no catalog match. */
+  priceBasis: 'extended' | 'per-unit' | 'assumed-extended';
   units: number;
   unitPrice: number;
   unitCost: number;
@@ -247,6 +249,8 @@ export interface AutotaskContractRecurringLines {
   monthlyTotal: number;
   monthlyCost: number;
   unresolvedPeriodTypes: number[];
+  /** Lines priced without a catalog cross-check; verify these against an invoice. */
+  assumedExtendedLines: number;
 }
 
 export interface AutotaskInvoice {

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -158,6 +158,97 @@ export interface AutotaskContract {
   [key: string]: any;
 }
 
+/** A service line on a Contract (Autotask entity ContractServices). */
+export interface AutotaskContractService {
+  id?: number;
+  contractID?: number;
+  serviceID?: number;
+  unitPrice?: number;
+  unitCost?: number;
+  internalCurrencyUnitPrice?: number;
+  invoiceDescription?: string;
+  internalDescription?: string;
+  quoteItemID?: number;
+  [key: string]: any;
+}
+
+/** Billed quantity for a contract service line over a date range (ContractServiceUnits). */
+export interface AutotaskContractServiceUnit {
+  id?: number;
+  contractID?: number;
+  contractServiceID?: number;
+  serviceID?: number;
+  units?: number;
+  price?: number;
+  cost?: number;
+  internalCurrencyPrice?: number;
+  startDate?: string;
+  endDate?: string;
+  approveAndPostDate?: string;
+  vendorAccountID?: number;
+  [key: string]: any;
+}
+
+/** A service-bundle line on a Contract (ContractServiceBundles). */
+export interface AutotaskContractServiceBundle {
+  id?: number;
+  contractID?: number;
+  serviceBundleID?: number;
+  unitPrice?: number;
+  unitCost?: number;
+  internalCurrencyUnitPrice?: number;
+  invoiceDescription?: string;
+  internalDescription?: string;
+  [key: string]: any;
+}
+
+/** Billed quantity for a contract bundle line over a date range (ContractServiceBundleUnits). */
+export interface AutotaskContractServiceBundleUnit {
+  id?: number;
+  contractID?: number;
+  contractServiceBundleID?: number;
+  serviceBundleID?: number;
+  units?: number;
+  price?: number;
+  cost?: number;
+  startDate?: string;
+  endDate?: string;
+  [key: string]: any;
+}
+
+/** One recurring line, normalized to a monthly figure, as returned by getContractRecurringLines(). */
+export interface AutotaskContractRecurringLine {
+  source: 'service' | 'bundle';
+  lineID: number | undefined;
+  serviceID?: number;
+  serviceBundleID?: number;
+  name: string;
+  vendorCompanyID?: number;
+  vendorName?: string;
+  periodType?: number;
+  periodLabel?: string;
+  units: number;
+  unitPrice: number;
+  unitCost: number;
+  periodTotal: number;
+  monthlyTotal: number;
+  monthlyCost: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface AutotaskContractRecurringLines {
+  contractID: number;
+  contractName?: string;
+  companyID?: number;
+  companyName?: string;
+  activeOn: string;
+  lines: AutotaskContractRecurringLine[];
+  monthlyTotal: number;
+  monthlyCost: number;
+  unresolvedPeriodTypes: number[];
+}
+
 export interface AutotaskInvoice {
   id?: number;
   companyID?: number;

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -185,7 +185,7 @@ export interface AutotaskContractServiceUnit {
   startDate?: string;
   endDate?: string;
   approveAndPostDate?: string;
-  vendorAccountID?: number;
+  vendorCompanyID?: number;
   [key: string]: any;
 }
 
@@ -220,28 +220,28 @@ export interface AutotaskContractServiceBundleUnit {
 export interface AutotaskContractRecurringLine {
   source: 'service' | 'bundle';
   lineID: number | undefined;
-  serviceID?: number;
-  serviceBundleID?: number;
+  serviceID?: number | undefined;
+  serviceBundleID?: number | undefined;
   name: string;
-  vendorCompanyID?: number;
-  vendorName?: string;
-  periodType?: number;
-  periodLabel?: string;
+  vendorCompanyID?: number | undefined;
+  vendorName?: string | undefined;
+  periodType?: number | undefined;
+  periodLabel?: string | undefined;
   units: number;
   unitPrice: number;
   unitCost: number;
   periodTotal: number;
   monthlyTotal: number;
   monthlyCost: number;
-  startDate?: string;
-  endDate?: string;
+  startDate?: string | undefined;
+  endDate?: string | undefined;
 }
 
 export interface AutotaskContractRecurringLines {
   contractID: number;
-  contractName?: string;
-  companyID?: number;
-  companyName?: string;
+  contractName?: string | undefined;
+  companyID?: number | undefined;
+  companyName?: string | undefined;
   activeOn: string;
   lines: AutotaskContractRecurringLine[];
   monthlyTotal: number;

--- a/tests/contract-service-lines.test.ts
+++ b/tests/contract-service-lines.test.ts
@@ -1,0 +1,260 @@
+// Contract service line / billed unit tool surface tests:
+// autotask_search_contract_services, autotask_search_contract_service_units,
+// autotask_search_contract_service_bundles, autotask_search_contract_service_bundle_units,
+// and the autotask_get_contract_recurring_lines roll-up.
+//
+// The periodType picklist used below is the live Services.periodType picklist
+// (2 Monthly, 3 Quarterly, 4 Semi-Annual, 5 Yearly) — these are the only four
+// values Autotask defines, so monthly normalization must resolve all of them
+// and leave unresolvedPeriodTypes empty.
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { TOOL_DEFINITIONS, TOOL_CATEGORIES } from '../src/handlers/tool.definitions';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const mockConfig: McpServerConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  autotask: {
+    username: 'test-username',
+    secret: 'test-secret',
+    integrationCode: 'test-integration-code'
+  }
+};
+
+const mockLogger = new Logger('error');
+
+const findTool = (name: string) => TOOL_DEFINITIONS.find(t => t.name === name);
+
+const NEW_TOOLS = [
+  'autotask_search_contract_services',
+  'autotask_search_contract_service_units',
+  'autotask_search_contract_service_bundles',
+  'autotask_search_contract_service_bundle_units',
+  'autotask_get_contract_recurring_lines',
+];
+
+const PERIOD_TYPE_FIELD = {
+  name: 'periodType',
+  dataType: 'integer',
+  isRequired: true,
+  isReadOnly: true,
+  isQueryable: true,
+  isReference: false,
+  isPickList: true,
+  picklistValues: [
+    { value: '2', label: 'Monthly' },
+    { value: '3', label: 'Quarterly' },
+    { value: '4', label: 'Semi-Annual' },
+    { value: '5', label: 'Yearly' },
+  ],
+};
+
+describe('contract service line tool definitions', () => {
+  test.each(NEW_TOOLS)('%s is defined and requires contractID', (name) => {
+    const tool = findTool(name);
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.contractID.type).toBe('number');
+    expect(tool!.inputSchema.required).toEqual(['contractID']);
+  });
+
+  test.each(NEW_TOOLS)('%s is listed in the financial category', (name) => {
+    expect(TOOL_CATEGORIES.financial.tools).toContain(name);
+  });
+
+  test('unit tools expose an optional activeOn date', () => {
+    for (const name of ['autotask_search_contract_service_units', 'autotask_search_contract_service_bundle_units']) {
+      const props = findTool(name)!.inputSchema.properties as Record<string, any>;
+      expect(props.activeOn.type).toBe('string');
+    }
+  });
+
+  test('all five tools are read-only — no create/update/delete verbs', () => {
+    for (const name of NEW_TOOLS) {
+      expect(name).not.toMatch(/_(create|update|delete)_/);
+    }
+  });
+});
+
+describe('contract service line handlers', () => {
+  test('autotask_search_contract_services forwards contractID and pageSize', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service, 'searchContractServices').mockResolvedValue([{ id: 1 }] as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_search_contract_services', { contractID: 29747643, pageSize: 50 });
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ contractID: 29747643, pageSize: 50 }));
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('autotask_search_contract_service_units forwards activeOn', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue([{ id: 1 }] as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    await handler.callTool('autotask_search_contract_service_units', { contractID: 7, activeOn: '2026-09-08' });
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ contractID: 7, activeOn: '2026-09-08' }));
+  });
+
+  test('autotask_search_contract_service_bundles and _bundle_units forward to their service methods', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const bundles = jest.spyOn(service, 'searchContractServiceBundles').mockResolvedValue([] as any);
+    const units = jest.spyOn(service, 'searchContractServiceBundleUnits').mockResolvedValue([] as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    await handler.callTool('autotask_search_contract_service_bundles', { contractID: 7 });
+    await handler.callTool('autotask_search_contract_service_bundle_units', { contractID: 7, activeOn: '2026-09-08' });
+    expect(bundles).toHaveBeenCalledWith(expect.objectContaining({ contractID: 7 }));
+    expect(units).toHaveBeenCalledWith(expect.objectContaining({ contractID: 7, activeOn: '2026-09-08' }));
+  });
+});
+
+describe('searchContractServiceUnits date filtering', () => {
+  test('activeOn becomes startDate lte / endDate gte filters on the given day', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const query = jest.fn().mockResolvedValue([]);
+    jest.spyOn(service as any, 'ensureClient').mockResolvedValue({ query });
+
+    await service.searchContractServiceUnits({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    const [entity, filters] = query.mock.calls[0];
+    expect(entity).toBe('ContractServiceUnits');
+    expect(filters).toEqual([
+      { op: 'eq', field: 'contractID', value: 29747643 },
+      { op: 'lte', field: 'startDate', value: '2026-09-08T23:59:59' },
+      { op: 'gte', field: 'endDate', value: '2026-09-08T00:00:00' },
+    ]);
+  });
+
+  test('pageSize is capped at 500', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const query = jest.fn().mockResolvedValue([]);
+    jest.spyOn(service as any, 'ensureClient').mockResolvedValue({ query });
+
+    await service.searchContractServiceUnits({ contractID: 1, activeOn: '2026-09-08', pageSize: 5000 });
+
+    expect(query.mock.calls[0][2]).toEqual({ maxRecords: 500 });
+  });
+});
+
+describe('getContractRecurringLines roll-up', () => {
+  const buildService = (overrides: Record<string, any> = {}) => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    jest.spyOn(service, 'getContract').mockResolvedValue({
+      id: 29747643, contractName: 'AIC - Cloud Services', companyID: 29746549,
+    } as any);
+    jest.spyOn(service, 'getFieldInfo').mockResolvedValue([PERIOD_TYPE_FIELD] as any);
+    jest.spyOn(service, 'getCompany').mockImplementation(async (id: number) => (
+      id === 29746549
+        ? { id, companyName: 'Advanced Industrial Coatings (AIC)' } as any
+        : { id, companyName: 'Microsoft' } as any
+    ));
+    jest.spyOn(service, 'searchContractServiceBundles').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServiceBundleUnits').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServices').mockResolvedValue(overrides.serviceLines ?? [] as any);
+    jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue(overrides.serviceUnits ?? [] as any);
+    jest.spyOn(service, 'getService').mockImplementation(async (id: number) => overrides.catalog?.[id] ?? null);
+    jest.spyOn(service, 'getServiceBundle').mockResolvedValue(null as any);
+    return service;
+  };
+
+  test('joins units to the catalog and reports name, vendor and monthly total', async () => {
+    const service = buildService({
+      serviceLines: [{ id: 900, contractID: 29747643, serviceID: 500, unitPrice: 22 }],
+      serviceUnits: [{
+        id: 1, contractID: 29747643, contractServiceID: 900, serviceID: 500,
+        units: 11, price: 22, cost: 18, startDate: '2026-09-01', endDate: '2026-09-30',
+      }],
+      catalog: { 500: { id: 500, name: 'Microsoft 365 Business Premium - A|M', periodType: 2, vendorCompanyID: 111, unitPrice: 22, unitCost: 18 } },
+    });
+
+    const result = await service.getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    expect(result.contractName).toBe('AIC - Cloud Services');
+    expect(result.companyName).toBe('Advanced Industrial Coatings (AIC)');
+    expect(result.activeOn).toBe('2026-09-08');
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0]).toEqual(expect.objectContaining({
+      source: 'service',
+      name: 'Microsoft 365 Business Premium - A|M',
+      vendorName: 'Microsoft',
+      periodLabel: 'Monthly',
+      units: 11,
+      unitPrice: 22,
+      periodTotal: 242,
+      monthlyTotal: 242,
+    }));
+    expect(result.monthlyTotal).toBe(242);
+    expect(result.unresolvedPeriodTypes).toEqual([]);
+  });
+
+  test('normalizes every live periodType to a monthly figure with none unresolved', async () => {
+    const service = buildService({
+      serviceLines: [
+        { id: 1, serviceID: 2, unitPrice: 120 },
+        { id: 2, serviceID: 3, unitPrice: 120 },
+        { id: 3, serviceID: 4, unitPrice: 120 },
+        { id: 4, serviceID: 5, unitPrice: 120 },
+      ],
+      serviceUnits: [
+        { id: 11, contractServiceID: 1, serviceID: 2, units: 1, price: 120 },
+        { id: 12, contractServiceID: 2, serviceID: 3, units: 1, price: 120 },
+        { id: 13, contractServiceID: 3, serviceID: 4, units: 1, price: 120 },
+        { id: 14, contractServiceID: 4, serviceID: 5, units: 1, price: 120 },
+      ],
+      catalog: {
+        2: { id: 2, name: 'Monthly svc', periodType: 2 },
+        3: { id: 3, name: 'Quarterly svc', periodType: 3 },
+        4: { id: 4, name: 'Semi-Annual svc', periodType: 4 },
+        5: { id: 5, name: 'Yearly svc', periodType: 5 },
+      },
+    });
+
+    const result = await service.getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+    const byName = Object.fromEntries(result.lines.map(l => [l.name, l.monthlyTotal]));
+
+    expect(byName['Monthly svc']).toBe(120);
+    expect(byName['Quarterly svc']).toBe(40);
+    expect(byName['Semi-Annual svc']).toBe(20);
+    expect(byName['Yearly svc']).toBe(10);
+    expect(result.unresolvedPeriodTypes).toEqual([]);
+    expect(result.monthlyTotal).toBe(190);
+  });
+
+  test('a periodType missing from the picklist is reported, not guessed silently', async () => {
+    const service = buildService({
+      serviceLines: [{ id: 1, serviceID: 9, unitPrice: 50 }],
+      serviceUnits: [{ id: 11, contractServiceID: 1, serviceID: 9, units: 2, price: 50 }],
+      catalog: { 9: { id: 9, name: 'Odd period svc', periodType: 99 } },
+    });
+
+    const result = await service.getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    expect(result.unresolvedPeriodTypes).toEqual([99]);
+    expect(result.lines[0].periodTotal).toBe(100);
+  });
+
+  test('a contract with no active units returns an empty lines array, not an error', async () => {
+    const service = buildService({ serviceLines: [], serviceUnits: [] });
+
+    const result = await service.getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    expect(result.lines).toEqual([]);
+    expect(result.monthlyTotal).toBe(0);
+    expect(result.unresolvedPeriodTypes).toEqual([]);
+  });
+
+  test('defaults activeOn to today when omitted', async () => {
+    const service = buildService({ serviceLines: [], serviceUnits: [] });
+
+    const result = await service.getContractRecurringLines({ contractID: 29747643 });
+
+    expect(result.activeOn).toBe(new Date().toISOString().slice(0, 10));
+  });
+});

--- a/tests/contract-service-lines.test.ts
+++ b/tests/contract-service-lines.test.ts
@@ -258,3 +258,137 @@ describe('getContractRecurringLines roll-up', () => {
     expect(result.activeOn).toBe(new Date().toISOString().slice(0, 10));
   });
 });
+
+// Regression tests for the price-basis fix. ContractServiceUnits.price is the
+// EXTENDED line amount on our tenant, not a per-unit rate — the original
+// roll-up multiplied by units a second time and reported AIC at $5,883.50/mo
+// against a real ~$482.60. The numbers below are the live AIC rows
+// (contract 29747643) and their catalog rates.
+describe('getContractRecurringLines price basis', () => {
+  const AIC_ROWS = [
+    { serviceID: 45,  units: 11, price: 254.10, catalogRate: 23.10, name: 'Microsoft 365 Business Premium - A|M' },
+    { serviceID: 134, units: 17, price: 63.75,  catalogRate: 3.75,  name: 'AvePoint Microsoft 365 Migration FLY (Server) M|M' },
+    { serviceID: 38,  units: 4,  price: 16.80,  catalogRate: 4.20,  name: 'Exchange Online (Plan 1)  - A|M' },
+    { serviceID: 57,  units: 1,  price: 9.45,   catalogRate: 9.45,  name: 'Service 57' },
+    { serviceID: 33,  units: 13, price: 32.50,  catalogRate: 2.50,  name: 'DNS Security Service Licensing - Umbrella - M|M' },
+    { serviceID: 78,  units: 15, price: 63.75,  catalogRate: 4.25,  name: 'Service 78' },
+    { serviceID: 41,  units: 13, price: 42.25,  catalogRate: 3.25,  name: 'Service 41' },
+  ];
+
+  const aicService = () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    jest.spyOn(service, 'getContract').mockResolvedValue({
+      id: 29747643, contractName: 'AIC - Cloud Services', companyID: 29746549,
+    } as any);
+    jest.spyOn(service, 'getFieldInfo').mockResolvedValue([PERIOD_TYPE_FIELD] as any);
+    jest.spyOn(service, 'getCompany').mockResolvedValue({ id: 1, companyName: 'Advanced Industrial Coatings (AIC)' } as any);
+    jest.spyOn(service, 'searchContractServiceBundles').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServiceBundleUnits').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServices').mockResolvedValue(
+      AIC_ROWS.map((r, i) => ({ id: 900 + i, serviceID: r.serviceID, unitPrice: r.catalogRate, invoiceDescription: '' })) as any
+    );
+    jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue(
+      AIC_ROWS.map((r, i) => ({ id: i, contractServiceID: 900 + i, serviceID: r.serviceID, units: r.units, price: r.price, cost: 0 })) as any
+    );
+    jest.spyOn(service, 'getService').mockImplementation(async (id: number) => {
+      const r = AIC_ROWS.find(x => x.serviceID === id)!;
+      return { id, name: r.name.startsWith('Service ') ? '' : r.name, unitPrice: r.catalogRate, unitCost: 0, periodType: 2 } as any;
+    });
+    jest.spyOn(service, 'getServiceBundle').mockResolvedValue(null as any);
+    return service;
+  };
+
+  test('reads price as the extended line amount and totals AIC at 482.60, not 5883.50', async () => {
+    const result = await aicService().getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    expect(result.monthlyTotal).toBe(482.60);
+    expect(result.monthlyTotal).not.toBe(5883.50);
+    expect(result.lines.every(l => l.priceBasis === 'extended')).toBe(true);
+    expect(result.assumedExtendedLines).toBe(0);
+  });
+
+  test('derives the per-unit price from the extended amount', async () => {
+    const result = await aicService().getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+    const bp = result.lines.find(l => l.serviceID === 45)!;
+
+    expect(bp.units).toBe(11);
+    expect(bp.periodTotal).toBe(254.10);
+    expect(bp.unitPrice).toBe(23.10);
+    expect(bp.monthlyTotal).toBe(254.10);
+  });
+
+  test('a genuinely per-unit row is not doubled', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    jest.spyOn(service, 'getContract').mockResolvedValue({ id: 1, companyID: 2 } as any);
+    jest.spyOn(service, 'getFieldInfo').mockResolvedValue([PERIOD_TYPE_FIELD] as any);
+    jest.spyOn(service, 'getCompany').mockResolvedValue({ id: 2, companyName: 'X' } as any);
+    jest.spyOn(service, 'searchContractServiceBundles').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServiceBundleUnits').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServices').mockResolvedValue([{ id: 900, serviceID: 45, unitPrice: 23.10 }] as any);
+    // price equals the catalog rate while units > 1 -> per-unit, so extend it.
+    jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue([
+      { id: 1, contractServiceID: 900, serviceID: 45, units: 11, price: 23.10, cost: 0 },
+    ] as any);
+    jest.spyOn(service, 'getService').mockResolvedValue({ id: 45, name: 'BP', unitPrice: 23.10, periodType: 2 } as any);
+    jest.spyOn(service, 'getServiceBundle').mockResolvedValue(null as any);
+
+    const result = await service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' });
+
+    expect(result.lines[0].priceBasis).toBe('per-unit');
+    expect(result.lines[0].periodTotal).toBe(254.10);
+    expect(result.monthlyTotal).toBe(254.10);
+  });
+
+  test('no catalog match is flagged assumed-extended and counted', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    jest.spyOn(service, 'getContract').mockResolvedValue({ id: 1, companyID: 2 } as any);
+    jest.spyOn(service, 'getFieldInfo').mockResolvedValue([PERIOD_TYPE_FIELD] as any);
+    jest.spyOn(service, 'getCompany').mockResolvedValue({ id: 2, companyName: 'X' } as any);
+    jest.spyOn(service, 'searchContractServiceBundles').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServiceBundleUnits').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServices').mockResolvedValue([{ id: 900, serviceID: 77 }] as any);
+    jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue([
+      { id: 1, contractServiceID: 900, serviceID: 77, units: 5, price: 100, cost: 0 },
+    ] as any);
+    jest.spyOn(service, 'getService').mockResolvedValue(null as any);
+    jest.spyOn(service, 'getServiceBundle').mockResolvedValue(null as any);
+
+    const result = await service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' });
+
+    expect(result.lines[0].priceBasis).toBe('assumed-extended');
+    expect(result.lines[0].periodTotal).toBe(100);
+    expect(result.assumedExtendedLines).toBe(1);
+  });
+
+  test('name falls through an empty catalog name and empty invoiceDescription', async () => {
+    const result = await aicService().getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    expect(result.lines.every(l => l.name.trim() !== '')).toBe(true);
+    expect(result.lines.find(l => l.serviceID === 57)!.name).toBe('Service 57');
+    expect(result.lines.find(l => l.serviceID === 45)!.name).toBe('Microsoft 365 Business Premium - A|M');
+  });
+
+  test('unitCost falls through a zero unit-row cost to the catalog rate', async () => {
+    const service = aicService();
+    jest.spyOn(service, 'getService').mockImplementation(async (id: number) => (
+      { id, name: 'Exchange Online (Plan 1)  - A|M', unitPrice: 4.20, unitCost: 3.36, periodType: 2 } as any
+    ));
+    jest.spyOn(service, 'searchContractServices').mockResolvedValue([{ id: 900, serviceID: 38, unitPrice: 4.20 }] as any);
+    jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue([
+      { id: 1, contractServiceID: 900, serviceID: 38, units: 4, price: 16.80, cost: 0 },
+    ] as any);
+
+    const result = await service.getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' });
+
+    expect(result.lines[0].unitCost).toBe(3.36);
+    expect(result.lines[0].monthlyCost).toBe(13.44);
+  });
+
+  test('a rate-limit error surfaces instead of degrading into blank rows', async () => {
+    const service = aicService();
+    jest.spyOn(service, 'getService').mockRejectedValue(new Error('Autotask API threshold exceeded (HTTP 429)'));
+
+    await expect(service.getContractRecurringLines({ contractID: 29747643, activeOn: '2026-09-08' }))
+      .rejects.toThrow(/429/);
+  });
+});

--- a/tests/contract-service-lines.test.ts
+++ b/tests/contract-service-lines.test.ts
@@ -392,3 +392,64 @@ describe('getContractRecurringLines price basis', () => {
       .rejects.toThrow(/429/);
   });
 });
+
+// The period-label cache used to be assigned outside its try/catch, so one
+// failed getFieldInfo cached an empty map for the process lifetime: every
+// periodType then resolved to null, `factor ?? 1` billed yearly lines as
+// monthly, and the contract total overstated by up to 12x. Flagged upstream on
+// PR #284.
+describe('servicePeriodLabels cache poisoning', () => {
+  const svcWithPicklist = (getFieldInfo: jest.Mock) => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    jest.spyOn(service, 'getFieldInfo').mockImplementation(getFieldInfo as any);
+    jest.spyOn(service, 'getContract').mockResolvedValue({ id: 1, companyID: 2 } as any);
+    jest.spyOn(service, 'getCompany').mockResolvedValue({ id: 2, companyName: 'X' } as any);
+    jest.spyOn(service, 'searchContractServiceBundles').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServiceBundleUnits').mockResolvedValue([] as any);
+    jest.spyOn(service, 'searchContractServices').mockResolvedValue([{ id: 900, serviceID: 81, unitPrice: 264 }] as any);
+    // One yearly line: 1 unit, extended price 264/yr -> must normalize to 22/mo.
+    jest.spyOn(service, 'searchContractServiceUnits').mockResolvedValue([
+      { id: 1, contractServiceID: 900, serviceID: 81, units: 1, price: 264, cost: 0 },
+    ] as any);
+    jest.spyOn(service, 'getService').mockResolvedValue(
+      { id: 81, name: 'Microsoft 365 Business Premium - A|A', unitPrice: 264, periodType: 5 } as any
+    );
+    jest.spyOn(service, 'getServiceBundle').mockResolvedValue(null as any);
+    return service;
+  };
+
+  test('a failed picklist load is not cached, and the next call recovers', async () => {
+    const getFieldInfo = jest.fn()
+      .mockRejectedValueOnce(new Error('Autotask API threshold exceeded (HTTP 429)'))
+      .mockResolvedValue([PERIOD_TYPE_FIELD]);
+    const service = svcWithPicklist(getFieldInfo);
+
+    await expect(service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' }))
+      .rejects.toThrow(/429/);
+
+    // Second call must retry the lookup rather than reuse a poisoned empty map.
+    const result = await service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' });
+    expect(getFieldInfo).toHaveBeenCalledTimes(2);
+    expect(result.lines[0].periodLabel).toBe('Yearly');
+    expect(result.lines[0].monthlyTotal).toBe(22);
+    expect(result.monthlyTotal).toBe(22);
+    expect(result.monthlyTotal).not.toBe(264);
+  });
+
+  test('an empty picklist raises instead of billing yearly lines as monthly', async () => {
+    const service = svcWithPicklist(jest.fn().mockResolvedValue([{ ...PERIOD_TYPE_FIELD, picklistValues: [] }]));
+
+    await expect(service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' }))
+      .rejects.toThrow(/cannot normalize/i);
+  });
+
+  test('a successful picklist load is cached across calls', async () => {
+    const getFieldInfo = jest.fn().mockResolvedValue([PERIOD_TYPE_FIELD]);
+    const service = svcWithPicklist(getFieldInfo);
+
+    await service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' });
+    await service.getContractRecurringLines({ contractID: 1, activeOn: '2026-09-08' });
+
+    expect(getFieldInfo).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Why

A contract header tells you nothing about what is actually invoiced under it — on our cloud-services contracts `estimatedRevenue` is 0 on every header. The lines and their unit quantities live in `ContractServices` / `ContractServiceUnits`, which the server did not query. This closes that gap so billed recurring revenue per contract is one call.

Read-only throughout. No create/update/delete tools.

## Tools

```
autotask_search_contract_services(contractID, pageSize?)
autotask_search_contract_service_units(contractID, activeOn?, pageSize?)
autotask_search_contract_service_bundles(contractID, pageSize?)
autotask_search_contract_service_bundle_units(contractID, activeOn?, pageSize?)
autotask_get_contract_recurring_lines(contractID, activeOn?)
```

`activeOn` is an ISO date defaulting to today; unit queries return rows whose start/end range covers that day. All five are registered in the `financial` category.

`autotask_get_contract_recurring_lines` is the roll-up: it joins active unit rows to the `Services` / `ServiceBundles` catalog for name, vendor and billing period, and normalizes each line to a monthly figure. Period types it cannot resolve from the `Services.periodType` picklist are returned in `unresolvedPeriodTypes` rather than guessed.

## Verified against live Autotask

- Field names checked against all four entities via `getFieldInfo`.
- `Services.periodType` has exactly four values (2 Monthly, 3 Quarterly, 4 Semi-Annual, 5 Yearly) and all four resolve, so `unresolvedPeriodTypes` is empty in practice. `ServiceBundles.periodType` is the identical picklist, so sharing the label map is safe.
- Sanity check on the normalization: `Microsoft 365 Business Premium - A|A` is periodType 5 at $264/yr, against `- A|M` at $23.10/mo — $22 vs $23.10 monthly, consistent.

## Tests

`tests/contract-service-lines.test.ts`, 22 tests: tool schemas and category membership, handler argument forwarding, the `activeOn` → `startDate lte` / `endDate gte` filter shape and the 500-row cap, and monthly normalization across all four live period types including the unresolved and empty-contract paths.

Full suite green: 26 suites, 268 tests.

## Notes for review

- The roll-up fans out one `getService` per distinct service and one `getCompany` per distinct vendor. Fine per contract; a bulk path across many contracts would want batching.
- `AutotaskContractServiceUnit` uses `vendorCompanyID` — the live entity returns that, not `vendorAccountID`.

Original work by Andrew Calori.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791486809&installation_model_id=431408&pr_number=284&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F284&signature=18cd9b7651c52d61a4953007eb144fb7f6b1c49d066be4fe5b9dcfd40e076ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only tools to view contract services, service units, service bundles, bundle units, and recurring billing lines.
  * Added filtering by contract, active date, and page size where applicable.
  * Added recurring billing summaries with normalized monthly totals, costs, vendor details, and unresolved billing-period reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->