### PR TITLE
fix(time-entries): use correct useType for regular billing code lookups

### DIFF
--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -752,7 +752,7 @@ export class AutotaskService {
       const results = await http.query<{ id: number; name: string }>(
         'BillingCodes',
         [
-          { op: 'eq', field: 'useType', value: 1 },
+          { op: 'eq', field: 'useType', value: 3 },
           { op: 'eq', field: 'isActive', value: true },
           { op: 'eq', field: 'name', value: name }
         ],

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -726,7 +726,7 @@ export class AutotaskService {
 
   /**
    * Return the list of internal (non-customer-facing) billing code names.
-   * Queries BillingCodes with useType = 1 (Internal Allocation Code).
+   * Queries BillingCodes with useType = 3 (Regular (Internal) Time).
    */
   async getInternalBillingCodeNames(): Promise<string[]> {
     const http = await this.ensureClient();
@@ -734,7 +734,7 @@ export class AutotaskService {
       const codes = await http.query<{ name: string }>(
         'BillingCodes',
         [
-          { op: 'eq', field: 'useType', value: 1 },
+          { op: 'eq', field: 'useType', value: 3 },
           { op: 'eq', field: 'isActive', value: true }
         ],
         { maxRecords: 500 }
@@ -745,7 +745,11 @@ export class AutotaskService {
       throw error;
     }
   }
-
+  
+  /**
+   * Resolves an internal billing code by name.
+   * Queries BillingCodes with useType = 3 (Regular (Internal) Time)
+   */
   async resolveInternalBillingCodeByName(name: string): Promise<{ id: number; name: string } | null> {
     const http = await this.ensureClient();
     try {


### PR DESCRIPTION
This PR changes the `useType` value for internal billing code lookups to `3` as this is the correct type for Regular (internal) Time as per the REST API documentation:

https://autotask.net/help/developerhelp/Content/APIs/REST/Entities/BillingCodesEntity.htm

The relevant section is reproduced below:

### BillingCode use types

The following table describes the values in the useType field picklist. These values determine how an BillingCode entity can be used in Autotask.

> NOTE If your company has enabled the Autotask System Setting that requires a Work Type on a Ticket, the Type 1 BillingCode is required to create or update a ticket

useType | Used for: | UI location
-- | -- | --
1 | Tickets (Labor) | > Admin > Features and Settings > Finance, Companying, & Invoicing > Billing Codes > Work Types tab
2 | Expenses | > Admin > Features and Settings > Finance, Companying, & Invoicing > Billing Codes > Expense Categories tab
3 | Regular (Internal) Time | > Admin > Features and Settings > Finance, Companying, & Invoicing > Billing Codes > Internal Time tab
4 | Material (RMA, Ticket, Project, and Contracts Costs) | > Admin > Features and Settings > Finance, Companying, & Invoicing > Billing Codes > Material tab
5 | Services | > Admin > Features and Settings > Finance, Companying, & Invoicing > Billing Codes > Service tab
6 | Milestones | > Admin > Features and Settings > Finance, Companying, & Invoicing > Billing Codes > Milestone tab

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791507270&installation_model_id=431408&pr_number=285&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F285&signature=c6e62b41e11700516d50f5453a6bda45924754f460a6b3ddbe3f8a4157fb585b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal billing code lookups now return active billing codes of the appropriate usage type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->