### PR TITLE
feat(tickets): accept dueDateTime on autotask_create_ticket

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -586,6 +586,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Queue ID to route the ticket to. Use autotask_list_queues to discover valid IDs.'
         },
+        dueDateTime: {
+          type: 'string',
+          description: 'Due date and time in ISO 8601 format (e.g. 2026-03-15T17:00:00Z). Autotask REQUIRES this on every new ticket unless the ticket category (or the API user\'s default category) supplies a default due date and time — without it the API answers "dueDateTime is required".'
+        },
         ticketCategory: {
           type: 'number',
           description: 'Ticket category ID (picklist). Use autotask_get_field_info with entityType "Tickets" and fieldName "ticketCategory" to discover valid values.'

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -33,6 +33,7 @@ const TICKET_WRITABLE_FIELDS = [
   'assignedResourceID',
   'contactID',
   'queueID',
+  'dueDateTime',
   'ticketCategory',
   'ticketType',
   'issueType',

--- a/tests/create-ticket-due-date.test.ts
+++ b/tests/create-ticket-due-date.test.ts
@@ -1,0 +1,95 @@
+// autotask_create_ticket dropped dueDateTime: it was neither advertised in the
+// tool schema nor in TICKET_WRITABLE_FIELDS, so a caller that supplied it had it
+// silently stripped from the payload — and Autotask answered
+// "dueDateTime is required.; on record number [0]" (HTTP 500), because the field
+// is required on every new ticket unless the ticket category defaults it.
+// (FellowHire: Synergy Solution IT, sansa-stark, 2026-09-09.)
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { TOOL_DEFINITIONS } from '../src/handlers/tool.definitions';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+import { _resetZoneUrlCache } from '../src/utils/config';
+
+const logger = new Logger('error');
+
+const config: McpServerConfig = {
+  name: 'test-server',
+  version: '0.0.0',
+  autotask: {
+    username: 'user@example.com',
+    secret: 'secret',
+    integrationCode: 'integration-code',
+    apiUrl: 'https://webservices2.autotask.net/ATServicesRest/',
+  },
+};
+
+function mockFetchOk(body: unknown): jest.SpyInstance {
+  return jest.spyOn(global, 'fetch' as any).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    text: async () => JSON.stringify(body),
+  } as unknown as Response);
+}
+
+function firstRequestBody(fetchMock: jest.SpyInstance): any {
+  return JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+}
+
+beforeEach(() => {
+  _resetZoneUrlCache();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('autotask_create_ticket dueDateTime', () => {
+  test('is advertised on the tool, as it is on autotask_update_ticket', () => {
+    const create = TOOL_DEFINITIONS.find(t => t.name === 'autotask_create_ticket');
+    const update = TOOL_DEFINITIONS.find(t => t.name === 'autotask_update_ticket');
+    expect((create!.inputSchema.properties as any).dueDateTime).toMatchObject({ type: 'string' });
+    expect((update!.inputSchema.properties as any).dueDateTime).toMatchObject({ type: 'string' });
+    expect((create!.inputSchema.properties as any).dueDateTime.description).toMatch(/REQUIRES/);
+  });
+
+  test('reaches the POST /Tickets payload instead of being stripped', async () => {
+    const fetchMock = mockFetchOk({ itemId: 19999 });
+    const service = new AutotaskService(config, logger);
+    const handler = new AutotaskToolHandler(service, logger);
+
+    const result = await handler.callTool('autotask_create_ticket', {
+      companyID: 1,
+      title: 'Dispatch Time Entry August',
+      description: 'Monthly dispatch time',
+      status: 1,
+      priority: 2,
+      dueDateTime: '2026-08-31T23:59:00Z',
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = firstRequestBody(fetchMock);
+    expect(body.dueDateTime).toBe('2026-08-31T23:59:00Z');
+    expect(body.title).toBe('Dispatch Time Entry August');
+  });
+
+  test('is optional: a call without it sends no dueDateTime key', async () => {
+    const fetchMock = mockFetchOk({ itemId: 20000 });
+    const service = new AutotaskService(config, logger);
+    const handler = new AutotaskToolHandler(service, logger);
+
+    await handler.callTool('autotask_create_ticket', {
+      companyID: 1, title: 't', description: 'd', status: 1, priority: 2,
+    });
+
+    expect(firstRequestBody(fetchMock)).not.toHaveProperty('dueDateTime');
+  });
+});


### PR DESCRIPTION
## Problem

`autotask_create_ticket` cannot create a ticket in a tenant whose ticket categories do not default a due date. Autotask requires `dueDateTime` on every new ticket unless the category (or the API user's default category) supplies both Due Date and Due Time, and answers:

```
POST /Tickets failed: HTTP 500: dueDateTime is required.; on record number [0].
```

The tool neither advertises `dueDateTime` nor lets it through `buildTicketPayload()`'s `TICKET_WRITABLE_FIELDS`, so a caller that supplies it has it silently stripped. `autotask_update_ticket` already accepts the field.

## Change

- Advertise `dueDateTime` on `autotask_create_ticket` with the same shape `autotask_update_ticket` uses, and a description that says when Autotask requires it.
- Add it to `TICKET_WRITABLE_FIELDS`.
- `tests/create-ticket-due-date.test.ts`: supplied, it reaches the `POST /Tickets` body; omitted, no key is sent; both tools advertise it.

Seen in production against a Datto Autotask tenant on 2026-09-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnU51VwHZTiKn8fyz58Tfh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791558475&installation_model_id=431408&pr_number=288&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F288&signature=5ca028e86bf2c5ba927fffb66e4bf7332a524d6175c03ccd08ece651e1be37e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket creation now supports an optional due date and time.
  * When provided, the due date and time are included in the new ticket request.
  * Ticket creation continues to work without this field when a default due date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->