### PR TITLE
feat(roles): discover and resolve Autotask role ids for ticket assignment and time entries

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -572,11 +572,15 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         },
         assignedResourceID: {
           type: 'number',
-          description: 'Assigned resource ID. If set, assignedResourceRoleID is also required by Autotask.'
+          description: 'Assigned resource ID. Autotask also requires that resource\'s role: pass assignedResourceRoleID or assignedResourceRoleName, or omit both and the resource\'s only active role is used (several roles = an error naming them).'
         },
         assignedResourceRoleID: {
           type: 'number',
-          description: 'Role ID for the assigned resource. Required by Autotask when assignedResourceID is set.'
+          description: 'Role ID for the assigned resource — one of that resource\'s roles (see autotask_search_resource_roles). Resolved automatically when omitted.'
+        },
+        assignedResourceRoleName: {
+          type: 'string',
+          description: 'Name of the assigned resource\'s role, e.g. "Help Desk", used instead of assignedResourceRoleID when the resource holds several roles.'
         },
         contactID: {
           type: 'number',
@@ -679,11 +683,15 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         },
         assignedResourceID: {
           type: 'number',
-          description: 'Assigned resource ID. If set, assignedResourceRoleID is also required by Autotask.'
+          description: 'Assigned resource ID. Autotask also requires that resource\'s role: pass assignedResourceRoleID or assignedResourceRoleName, or omit both and the resource\'s only active role is used (several roles = an error naming them).'
         },
         assignedResourceRoleID: {
           type: 'number',
-          description: 'Role ID for the assigned resource. Required by Autotask when assignedResourceID is set.'
+          description: 'Role ID for the assigned resource — one of that resource\'s roles (see autotask_search_resource_roles). Resolved automatically when omitted.'
+        },
+        assignedResourceRoleName: {
+          type: 'string',
+          description: 'Name of the assigned resource\'s role, e.g. "Help Desk", used instead of assignedResourceRoleID when the resource holds several roles.'
         },
         dueDateTime: {
           type: 'string',
@@ -906,6 +914,29 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     }
   },
 
+  {
+    name: 'autotask_search_resource_roles',
+    description: 'List the billing roles a resource (user) holds in Autotask, with names and role IDs. A ticket assigned to a resource and every ticket/task time entry need one of these role IDs; this is where to find them instead of guessing. Give resourceId or resourceName. Active roles only unless includeInactive is true.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        resourceId: {
+          type: 'number',
+          description: 'Resource (user) ID'
+        },
+        resourceName: {
+          type: 'string',
+          description: 'Resource name, e.g. "Ryan Rampersaud", resolved to a resourceId when resourceId is not given'
+        },
+        includeInactive: {
+          type: 'boolean',
+          description: 'Also list inactive role assignments (default false)'
+        }
+      }
+    },
+    annotations: { readOnlyHint: true }
+  },
+
   // Time entry tools
   {
     name: 'autotask_create_time_entry',
@@ -931,7 +962,11 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         },
         roleID: {
           type: 'number',
-          description: 'Role ID associated with the time entry. Optional as this will default to ticketID.assignedResourceroleID or taskID.assignedResourceroleID for Ticket and Task time entries respectively and will be ignored for Regular Time entries. If the system setting "Allow users to modify Role when creating/editing time entries on tickets" is enabled this may be set to a different Role ID.'
+          description: 'Role ID for a ticket/task time entry — must be one of the logging resource\'s active roles (see autotask_search_resource_roles). Optional: when omitted, the parent ticket/task\'s assigned role is used if the parent is assigned to this same resource, else the resource\'s only active role; a resource with several roles must be told which one (roleName or roleID). Ignored for Regular Time.'
+        },
+        roleName: {
+          type: 'string',
+          description: 'Name of the logging resource\'s role, e.g. "Help Desk", used instead of roleID. Case-insensitive; must match exactly one of the resource\'s active roles.'
         },
         category: {
           type: 'string',
@@ -3253,7 +3288,7 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
   },
   resources: {
     description: 'Search for Autotask resources (technicians/staff)',
-    tools: ['autotask_search_resources']
+    tools: ['autotask_search_resources', 'autotask_search_resource_roles']
   },
   configuration_items: {
     description: 'Search configuration items (assets/devices)',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -31,6 +31,7 @@ const TICKET_WRITABLE_FIELDS = [
   'status',
   'priority',
   'assignedResourceID',
+  'assignedResourceRoleID',
   'contactID',
   'queueID',
   'dueDateTime',
@@ -800,22 +801,43 @@ export class AutotaskToolHandler {
     return TOOL_DEFINITIONS;
   }
 
-  /**
-   * Resolve the roleID for a ticket- or task-scoped time entry from the
-   * parent's assignedResourceRoleID. Used by autotask_create_time_entry when
-   * the caller didn't supply an explicit roleID.
-   */
-  private async resolveParentRoleID(kind: 'Ticket' | 'Task', id: number): Promise<number> {
+  private async loadParent(kind: 'Ticket' | 'Task', id: number): Promise<{ assignedResourceID?: number | null; assignedResourceRoleID?: number | null }> {
     const parent = kind === 'Ticket'
       ? await this.autotaskService.getTicket(id)
       : await this.autotaskService.getTask(id);
     if (parent === null) {
       throw new Error(`No ${kind} found matching "${id}"`);
     }
-    if (parent.assignedResourceRoleID === undefined) {
-      throw new Error(`No "assignedResourceRoleID" found for ${kind} "${id}" and no roleID provided`);
+    return parent as { assignedResourceID?: number | null; assignedResourceRoleID?: number | null };
+  }
+
+  /**
+   * The roleID for a ticket/task time entry when the caller named none.
+   *
+   * The parent's assigned role is only right when the parent is assigned to
+   * the SAME resource logging the time: a roleID must be one of the entry's
+   * resource's own roles, so a ticket assigned to a colleague contributes
+   * nothing. Everything else resolves from the resource's active roles.
+   */
+  private async resolveTimeEntryRoleID(a: Record<string, any>): Promise<number> {
+    const kind: 'Ticket' | 'Task' = a.taskID ? 'Task' : 'Ticket';
+    const parent = await this.loadParent(kind, a.taskID ?? a.ticketID);
+    if (parent.assignedResourceRoleID != null && parent.assignedResourceID === a.resourceID) {
+      return parent.assignedResourceRoleID;
     }
-    return parent.assignedResourceRoleID;
+    return this.autotaskService.resolveRoleForResource(a.resourceID);
+  }
+
+  /**
+   * Autotask refuses a ticket that names an assigned resource without that
+   * resource's role. Fill the role from the resource's own assignments (or
+   * the caller's role name) so a caller need not know role ids.
+   */
+  private async fillAssignedResourceRole(payload: Record<string, any>, roleName?: string): Promise<void> {
+    if (payload.assignedResourceID == null || payload.assignedResourceRoleID != null) {
+      return;
+    }
+    payload.assignedResourceRoleID = await this.autotaskService.resolveRoleForResource(payload.assignedResourceID, roleName);
   }
 
   /**
@@ -884,12 +906,14 @@ export class AutotaskToolHandler {
       }],
       ['autotask_create_ticket', async (a) => {
         const payload = buildTicketPayload(a);
+        await this.fillAssignedResourceRole(payload, a.assignedResourceRoleName);
         const id = await s.createTicket(payload);
         return { result: id, message: `Successfully created ticket with ID: ${id}` };
       }],
       ['autotask_update_ticket', async (a) => {
         const { ticketId, ...rest } = a;
         const payload = buildTicketPayload(rest);
+        await this.fillAssignedResourceRole(payload, rest.assignedResourceRoleName);
         await s.updateTicket(ticketId, payload);
         return { result: ticketId, message: `Successfully updated ticket ${ticketId}` };
       }],
@@ -1018,14 +1042,18 @@ export class AutotaskToolHandler {
             delete a.category;
           }
         } else {
-          // for non-regular time entries a roleID must be set
-          // this defaults to ticketID.assignedResourceroleID or taskID.assignedResourceroleID but may be overridden
+          // A ticket/task time entry must carry a roleID, and it must be one
+          // of THIS resource's roles. Order: a role named by the caller; the
+          // parent's assigned role when the parent is assigned to this same
+          // resource; else the resource's own roles (their only one, or an
+          // error that lists them by name).
           if (!a.roleID) {
-            a.roleID = a.taskID
-              ? await this.resolveParentRoleID('Task', a.taskID)
-              : await this.resolveParentRoleID('Ticket', a.ticketID);
+            a.roleID = a.roleName
+              ? await s.resolveRoleForResource(a.resourceID, a.roleName)
+              : await this.resolveTimeEntryRoleID(a);
           }
         }
+        delete a.roleName;
         const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
       }],
 
@@ -1071,6 +1099,26 @@ export class AutotaskToolHandler {
       // Resources
       ['autotask_search_resources', async (a) => {
         const r = await s.searchResources(a); return { result: r, message: `Found ${r.length} resources` };
+      }],
+      ['autotask_search_resource_roles', async (a) => {
+        let resourceId: number | undefined = a.resourceId;
+        if (resourceId === undefined && a.resourceName) {
+          const resource = await s.resolveResourceByName(a.resourceName);
+          if (!resource) {
+            throw new Error(`No resource found matching "${a.resourceName}"`);
+          }
+          resourceId = resource.id;
+        }
+        if (resourceId === undefined) {
+          throw new Error('Provide resourceId or resourceName.');
+        }
+        const r = await s.searchResourceRoles(resourceId, a.includeInactive === true);
+        return {
+          result: r,
+          message: r.length === 0
+            ? `Resource ${resourceId} has no ${a.includeInactive ? '' : 'active '}roles.`
+            : `Resource ${resourceId} holds ${r.length} role(s): ${r.map(x => `${x.roleName} (roleID ${x.roleID})`).join(', ')}`
+        };
       }],
 
       // Configuration Items

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -50,7 +50,10 @@ import {
   AutotaskServiceCall,
   AutotaskServiceCallTicket,
   AutotaskServiceCallTicketResource,
-  AutotaskPhase
+  AutotaskPhase,
+  AutotaskResourceRole,
+  AutotaskRole,
+  AutotaskResourceRoleSummary
 } from '../types/autotask';
 import { McpServerConfig } from '../types/mcp';
 import { Logger } from '../utils/logger';
@@ -902,6 +905,83 @@ export class AutotaskService {
       this.logger.error(`Failed to get resource ${id}:`, error);
       throw error;
     }
+  }
+
+  /**
+   * The billing roles a resource holds (Autotask ResourceRoles joined to
+   * Roles for the names). Active assignments only unless asked otherwise.
+   *
+   * Two queries, both filtered: never an enumeration of every role in the
+   * tenant.
+   */
+  async searchResourceRoles(resourceId: number, includeInactive = false): Promise<AutotaskResourceRoleSummary[]> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Searching roles for resource ${resourceId}`);
+      const filters: QueryFilter[] = [{ op: 'eq', field: 'resourceID', value: resourceId }];
+      if (!includeInactive) {
+        filters.push({ op: 'eq', field: 'isActive', value: true });
+      }
+      const assignments = await http.query<AutotaskResourceRole>('ResourceRoles', filters, { maxRecords: 100 });
+      if (assignments.length === 0) {
+        return [];
+      }
+      const roleIds = [...new Set(assignments.map(a => a.roleID))];
+      const roles = await http.query<AutotaskRole>(
+        'Roles',
+        [{ op: 'in', field: 'id', value: roleIds }],
+        { maxRecords: Math.max(roleIds.length, 1) }
+      );
+      const byId = new Map(roles.map(r => [r.id, r]));
+      const summaries = assignments.map(a => ({
+        roleID: a.roleID,
+        roleName: byId.get(a.roleID)?.name ?? `Role ${a.roleID}`,
+        resourceID: a.resourceID,
+        isActive: a.isActive !== false,
+        departmentID: a.departmentID,
+        hourlyRate: a.hourlyRate,
+      }));
+      this.logger.info(`Retrieved ${summaries.length} roles for resource ${resourceId}`);
+      return summaries;
+    } catch (error) {
+      this.logger.error(`Failed to search roles for resource ${resourceId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * The one roleID to use for a resource: their only active role, or the
+   * active role whose name matches `roleName`. Anything ambiguous is refused
+   * with the resource's roles spelled out (name and id), so the caller can
+   * choose by name next time instead of guessing an id — Autotask answers a
+   * wrong id with "Role does not exist or is invalid", which says nothing
+   * about what would have been right.
+   */
+  async resolveRoleForResource(resourceId: number, roleName?: string): Promise<number> {
+    const roles = await this.searchResourceRoles(resourceId);
+    const list = roles.map(r => `${r.roleName} (roleID ${r.roleID})`).join(', ');
+
+    if (roles.length === 0) {
+      throw new Error(`Resource ${resourceId} has no active roles in Autotask, so no roleID can be chosen for them. An Autotask administrator must assign the resource a role first.`);
+    }
+
+    const wanted = roleName?.trim().toLowerCase();
+    if (wanted) {
+      const exact = roles.filter(r => r.roleName.toLowerCase() === wanted);
+      const matches = exact.length > 0 ? exact : roles.filter(r => r.roleName.toLowerCase().includes(wanted));
+      if (matches.length === 1) {
+        return matches[0].roleID;
+      }
+      throw new Error(matches.length === 0
+        ? `Resource ${resourceId} has no active role matching "${roleName}". Their roles: ${list}.`
+        : `"${roleName}" matches more than one of resource ${resourceId}'s roles: ${matches.map(r => `${r.roleName} (roleID ${r.roleID})`).join(', ')}. Give the full role name.`);
+    }
+
+    if (roles.length === 1) {
+      return roles[0].roleID;
+    }
+
+    throw new Error(`Resource ${resourceId} holds ${roles.length} active roles and Autotask needs exactly one: ${list}. Pass roleName (or roleID) to choose.`);
   }
 
   async searchResources(options: AutotaskQueryOptions = {}): Promise<AutotaskResource[]> {

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -933,14 +933,27 @@ export class AutotaskService {
         { maxRecords: Math.max(roleIds.length, 1) }
       );
       const byId = new Map(roles.map(r => [r.id, r]));
-      const summaries = assignments.map(a => ({
-        roleID: a.roleID,
-        roleName: byId.get(a.roleID)?.name ?? `Role ${a.roleID}`,
-        resourceID: a.resourceID,
-        isActive: a.isActive !== false,
-        departmentID: a.departmentID,
-        hourlyRate: a.hourlyRate,
-      }));
+      // One row per ROLE, not per assignment: Autotask holds a ResourceRoles
+      // row per (resource, role, department/queue), so a person with one role
+      // across five queues comes back five times — and would otherwise look
+      // like five roles to choose between. The first assignment's department
+      // and rate are kept as representative.
+      const summaries: AutotaskResourceRoleSummary[] = [];
+      const seen = new Set<number>();
+      for (const a of assignments) {
+        if (seen.has(a.roleID)) {
+          continue;
+        }
+        seen.add(a.roleID);
+        summaries.push({
+          roleID: a.roleID,
+          roleName: byId.get(a.roleID)?.name ?? `Role ${a.roleID}`,
+          resourceID: a.resourceID,
+          isActive: a.isActive !== false,
+          departmentID: a.departmentID,
+          hourlyRate: a.hourlyRate,
+        });
+      }
       this.logger.info(`Retrieved ${summaries.length} roles for resource ${resourceId}`);
       return summaries;
     } catch (error) {

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -700,3 +700,38 @@ export enum CompanyType {
   Vendor = 5,
   Partner = 6
 } 
+/**
+ * One row of Autotask's ResourceRoles entity: a resource's assignment to a
+ * billing role. Every ticket/task time entry must carry a roleID that is one
+ * of the entry's resource's ACTIVE assignments, and a ticket assigned to a
+ * resource must name one of that resource's roles too.
+ */
+export interface AutotaskResourceRole {
+  id: number;
+  resourceID: number;
+  roleID: number;
+  departmentID?: number;
+  queueID?: number;
+  hourlyRate?: number;
+  isActive?: boolean;
+}
+
+/** Autotask's Roles entity: the billing role a ResourceRoles row points at. */
+export interface AutotaskRole {
+  id: number;
+  name: string;
+  description?: string;
+  isActive?: boolean;
+  isSystemRole?: boolean;
+  hourlyRate?: number;
+}
+
+/** What autotask_search_resource_roles returns: an assignment joined to its role's name. */
+export interface AutotaskResourceRoleSummary {
+  roleID: number;
+  roleName: string;
+  resourceID: number;
+  isActive: boolean;
+  departmentID?: number | undefined;
+  hourlyRate?: number | undefined;
+}

--- a/src/utils/response.formatter.ts
+++ b/src/utils/response.formatter.ts
@@ -22,7 +22,7 @@ export interface CompactResponse {
  * These are the minimum fields needed for identification and triage.
  */
 const SUMMARY_FIELDS: Record<EntityType, string[]> = {
-  tickets: ['id', 'ticketNumber', 'title', 'status', 'priority', 'companyID', 'assignedResourceID', 'createDate', 'dueDateTime'],
+  tickets: ['id', 'ticketNumber', 'title', 'status', 'priority', 'companyID', 'assignedResourceID', 'assignedResourceRoleID', 'createDate', 'dueDateTime'],
   companies: ['id', 'companyName', 'isActive', 'phone', 'city', 'state'],
   contacts: ['id', 'firstName', 'lastName', 'emailAddress', 'companyID'],
   projects: ['id', 'projectName', 'status', 'companyID', 'projectLeadResourceID', 'startDate', 'endDate'],
@@ -30,7 +30,7 @@ const SUMMARY_FIELDS: Record<EntityType, string[]> = {
   resources: ['id', 'firstName', 'lastName', 'email', 'isActive'],
   billingItems: ['id', 'itemName', 'companyID', 'ticketID', 'projectID', 'postedDate', 'totalAmount', 'invoiceID', 'billingItemType'],
   billingItemApprovalLevels: ['id', 'timeEntryID', 'approvalLevel', 'approvalResourceID', 'approvalDateTime'],
-  timeEntries: ['id', 'resourceID', 'ticketID', 'taskID', 'dateWorked', 'hoursWorked', 'summaryNotes'],
+  timeEntries: ['id', 'resourceID', 'roleID', 'ticketID', 'taskID', 'dateWorked', 'hoursWorked', 'summaryNotes'],
 };
 
 /**

--- a/tests/create-time-entry-roleid.test.ts
+++ b/tests/create-time-entry-roleid.test.ts
@@ -1,8 +1,9 @@
 // Tests for autotask_create_time_entry auto-populating roleID on non-Regular
 // (ticket- or task-scoped) time entries: it defaults to the parent's
-// assignedResourceRoleID, may be overridden by an explicit roleID, and throws
-// an actionable error when neither the override nor the parent's role is
-// available.
+// assignedResourceRoleID when the parent is assigned to the SAME resource
+// logging the time, may be overridden by an explicit roleID, falls back to the
+// resource's own active roles otherwise (see tests/resource-roles.test.ts), and
+// throws an actionable error when none of those yields a role.
 
 jest.mock('autotask-node', () => ({
   AutotaskClient: {
@@ -33,8 +34,11 @@ function makeHandler() {
   const getTicketSpy = jest.spyOn(service, 'getTicket');
   const getTaskSpy = jest.spyOn(service, 'getTask');
   const createSpy = jest.spyOn(service, 'createTimeEntry').mockResolvedValue(4242);
+  // Resource 12 holds no roles unless a test says otherwise, so the fallback
+  // to the resource's own roles is observable as its "no active roles" error.
+  const rolesSpy = jest.spyOn(service, 'searchResourceRoles').mockResolvedValue([]);
   const handler = new AutotaskToolHandler(service, logger);
-  return { service, handler, getTicketSpy, getTaskSpy, createSpy };
+  return { service, handler, getTicketSpy, getTaskSpy, createSpy, rolesSpy };
 }
 
 afterEach(() => {
@@ -44,7 +48,7 @@ afterEach(() => {
 describe('autotask_create_time_entry roleID defaulting', () => {
   test('happy path (ticket-scoped): roleID defaults from ticket.assignedResourceRoleID', async () => {
     const { handler, getTicketSpy, getTaskSpy, createSpy } = makeHandler();
-    getTicketSpy.mockResolvedValue({ id: 48231, assignedResourceRoleID: 7 } as any);
+    getTicketSpy.mockResolvedValue({ id: 48231, assignedResourceID: 12, assignedResourceRoleID: 7 } as any);
 
     const result = await handler.callTool('autotask_create_time_entry', {
       ticketID: 48231,
@@ -60,7 +64,7 @@ describe('autotask_create_time_entry roleID defaulting', () => {
 
   test('happy path (task-scoped): roleID defaults from task.assignedResourceRoleID', async () => {
     const { handler, getTicketSpy, getTaskSpy, createSpy } = makeHandler();
-    getTaskSpy.mockResolvedValue({ id: 777, assignedResourceRoleID: 9 } as any);
+    getTaskSpy.mockResolvedValue({ id: 777, assignedResourceID: 12, assignedResourceRoleID: 9 } as any);
 
     const result = await handler.callTool('autotask_create_time_entry', {
       taskID: 777,
@@ -90,8 +94,24 @@ describe('autotask_create_time_entry roleID defaulting', () => {
     expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ ticketID: 48231, roleID: 3 }));
   });
 
-  test('throws when the ticket has no assignedResourceRoleID and no roleID was provided', async () => {
-    const { handler, getTicketSpy, createSpy } = makeHandler();
+  test('a ticket assigned to someone else lends no role: the resource\'s own roles decide', async () => {
+    const { handler, getTicketSpy, createSpy, rolesSpy } = makeHandler();
+    getTicketSpy.mockResolvedValue({ id: 48231, assignedResourceID: 99, assignedResourceRoleID: 7 } as any);
+    rolesSpy.mockResolvedValue([{ roleID: 5, roleName: 'Help Desk', resourceID: 12, isActive: true }]);
+
+    const result = await handler.callTool('autotask_create_time_entry', {
+      ticketID: 48231,
+      resourceID: 12,
+      hoursWorked: 1.5,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(rolesSpy).toHaveBeenCalledWith(12);
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ ticketID: 48231, roleID: 5 }));
+  });
+
+  test('throws when the ticket has no assignedResourceRoleID, no roleID was provided, and the resource has no roles', async () => {
+    const { handler, getTicketSpy, createSpy, rolesSpy } = makeHandler();
     getTicketSpy.mockResolvedValue({ id: 48231 } as any);
 
     const result = await handler.callTool('autotask_create_time_entry', {
@@ -101,14 +121,14 @@ describe('autotask_create_time_entry roleID defaulting', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/assignedResourceRoleID/);
-    expect(result.content[0].text).toContain('Ticket');
-    expect(result.content[0].text).toContain('48231');
+    expect(rolesSpy).toHaveBeenCalledWith(12);
+    expect(result.content[0].text).toContain('no active roles');
+    expect(result.content[0].text).toContain('12');
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  test('throws when the task has no assignedResourceRoleID and no roleID was provided', async () => {
-    const { handler, getTaskSpy, createSpy } = makeHandler();
+  test('throws when the task has no assignedResourceRoleID, no roleID was provided, and the resource has no roles', async () => {
+    const { handler, getTaskSpy, createSpy, rolesSpy } = makeHandler();
     getTaskSpy.mockResolvedValue({ id: 777 } as any);
 
     const result = await handler.callTool('autotask_create_time_entry', {
@@ -118,9 +138,8 @@ describe('autotask_create_time_entry roleID defaulting', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/assignedResourceRoleID/);
-    expect(result.content[0].text).toContain('Task');
-    expect(result.content[0].text).toContain('777');
+    expect(rolesSpy).toHaveBeenCalledWith(12);
+    expect(result.content[0].text).toContain('no active roles');
     expect(createSpy).not.toHaveBeenCalled();
   });
 

--- a/tests/resource-roles.test.ts
+++ b/tests/resource-roles.test.ts
@@ -1,0 +1,292 @@
+// Role ids are Autotask's gate on two everyday writes — a ticket assigned to
+// a resource, and any ticket/task time entry — and until now nothing here
+// could discover one: no tool listed a resource's roles, the compact search
+// formatter stripped roleID / assignedResourceRoleID from every result, and
+// autotask_create_ticket dropped assignedResourceRoleID from its payload
+// even when a caller knew it. A fellow was left guessing ids, which Autotask
+// answers with "Role does not exist or is invalid" and nothing more.
+// (FellowHire: Synergy Solution IT, sansa-stark, 2026-09-10.)
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { TOOL_DEFINITIONS, TOOL_CATEGORIES } from '../src/handlers/tool.definitions';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { formatCompactResponse } from '../src/utils/response.formatter';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+import { _resetZoneUrlCache } from '../src/utils/config';
+
+const logger = new Logger('error');
+
+const config: McpServerConfig = {
+  name: 'test-server',
+  version: '0.0.0',
+  autotask: {
+    username: 'user@example.com',
+    secret: 'secret',
+    integrationCode: 'integration-code',
+    apiUrl: 'https://webservices2.autotask.net/ATServicesRest/',
+  },
+};
+
+type Route = (body: any) => unknown;
+
+/**
+ * A fetch that answers by URL suffix, so a test can script ResourceRoles,
+ * Roles, Tickets and TimeEntries independently and then read back what was
+ * POSTed where.
+ */
+function mockAutotask(routes: Record<string, Route>): { calls: Array<{ path: string; method: string; body: any }> } {
+  const calls: Array<{ path: string; method: string; body: any }> = [];
+  jest.spyOn(global, 'fetch' as any).mockImplementation(async (url: any, init: any) => {
+    const path = String(url).replace(/^.*ATServicesRest\/?(v1\.0)?/, '');
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ path, method: init?.method ?? 'GET', body });
+    const key = Object.keys(routes).find(k => path.endsWith(k));
+    if (!key) {
+      return { ok: false, status: 404, headers: { get: () => null }, text: async () => `no route for ${path}` } as unknown as Response;
+    }
+    return { ok: true, status: 200, headers: { get: () => null }, text: async () => JSON.stringify(routes[key](body)) } as unknown as Response;
+  });
+  return { calls };
+}
+
+const RYAN = 29682887;
+
+const ryanRoles = {
+  '/ResourceRoles/query': () => ({ items: [
+    { id: 1, resourceID: RYAN, roleID: 501, isActive: true, departmentID: 7, hourlyRate: 150 },
+    { id: 2, resourceID: RYAN, roleID: 502, isActive: true, departmentID: 7, hourlyRate: 175 },
+  ], pageDetails: { count: 2 } }),
+  '/Roles/query': () => ({ items: [
+    { id: 501, name: 'Help Desk', isActive: true },
+    { id: 502, name: 'Engineer', isActive: true },
+  ], pageDetails: { count: 2 } }),
+};
+
+const oneRole = {
+  '/ResourceRoles/query': () => ({ items: [{ id: 1, resourceID: RYAN, roleID: 501, isActive: true }], pageDetails: { count: 1 } }),
+  '/Roles/query': () => ({ items: [{ id: 501, name: 'Help Desk', isActive: true }], pageDetails: { count: 1 } }),
+};
+
+function handler(): AutotaskToolHandler {
+  return new AutotaskToolHandler(new AutotaskService(config, logger), logger);
+}
+
+function posted(calls: Array<{ path: string; method: string; body: any }>, suffix: string): any {
+  const call = calls.find(c => c.method === 'POST' && c.path.endsWith(suffix) && !c.path.endsWith('/query'));
+  expect(call).toBeDefined();
+  return call!.body;
+}
+
+beforeEach(() => {
+  _resetZoneUrlCache();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('autotask_search_resource_roles', () => {
+  test('is advertised, read-only, and filed under resources', () => {
+    const tool = TOOL_DEFINITIONS.find(t => t.name === 'autotask_search_resource_roles');
+    expect(tool).toBeDefined();
+    expect(tool!.annotations?.readOnlyHint).toBe(true);
+    expect(TOOL_CATEGORIES.resources.tools).toContain('autotask_search_resource_roles');
+  });
+
+  test('joins a resource\'s active assignments to the role names', async () => {
+    const { calls } = mockAutotask(ryanRoles);
+
+    const result = await handler().callTool('autotask_search_resource_roles', { resourceId: RYAN });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content[0] as any).text as string;
+    expect(text).toContain('Help Desk (roleID 501)');
+    expect(text).toContain('Engineer (roleID 502)');
+
+    // Filtered on the resource and on active, never an enumeration.
+    const rolesQuery = calls.find(c => c.path.endsWith('/ResourceRoles/query'))!.body;
+    expect(rolesQuery.filter).toEqual(expect.arrayContaining([
+      { op: 'eq', field: 'resourceID', value: RYAN },
+      { op: 'eq', field: 'isActive', value: true },
+    ]));
+    const namesQuery = calls.find(c => c.path.endsWith('/Roles/query'))!.body;
+    expect(namesQuery.filter).toEqual([{ op: 'in', field: 'id', value: [501, 502] }]);
+  });
+
+  test('resolves resourceName when no id is given', async () => {
+    mockAutotask({
+      '/Resources/query': () => ({ items: [{ id: RYAN, firstName: 'Ryan', lastName: 'Rampersaud', isActive: true }], pageDetails: { count: 1 } }),
+      ...oneRole,
+    });
+
+    const result = await handler().callTool('autotask_search_resource_roles', { resourceName: 'Ryan Rampersaud' });
+
+    expect(result.isError).toBeFalsy();
+    expect((result.content[0] as any).text).toContain('Help Desk (roleID 501)');
+  });
+});
+
+describe('autotask_create_ticket assigned resource role', () => {
+  test('assignedResourceRoleID reaches the payload instead of being stripped', async () => {
+    const { calls } = mockAutotask({ '/Tickets': () => ({ itemId: 19900 }) });
+
+    const result = await handler().callTool('autotask_create_ticket', {
+      companyID: 1, title: 't', description: 'd', status: 1, priority: 2,
+      assignedResourceID: RYAN, assignedResourceRoleID: 501,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = posted(calls, '/Tickets');
+    expect(body.assignedResourceID).toBe(RYAN);
+    expect(body.assignedResourceRoleID).toBe(501);
+    // Nothing looked up: the caller already knew the role.
+    expect(calls.some(c => c.path.endsWith('/ResourceRoles/query'))).toBe(false);
+  });
+
+  test('fills the role from the resource\'s only active role when none is given', async () => {
+    const { calls } = mockAutotask({ ...oneRole, '/Tickets': () => ({ itemId: 19901 }) });
+
+    const result = await handler().callTool('autotask_create_ticket', {
+      companyID: 1, title: 't', description: 'd', status: 1, priority: 2, assignedResourceID: RYAN,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(posted(calls, '/Tickets').assignedResourceRoleID).toBe(501);
+  });
+
+  test('picks the role by name when the resource holds several', async () => {
+    const { calls } = mockAutotask({ ...ryanRoles, '/Tickets': () => ({ itemId: 19902 }) });
+
+    const result = await handler().callTool('autotask_create_ticket', {
+      companyID: 1, title: 't', description: 'd', status: 1, priority: 2,
+      assignedResourceID: RYAN, assignedResourceRoleName: 'help desk',
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = posted(calls, '/Tickets');
+    expect(body.assignedResourceRoleID).toBe(501);
+    expect(body).not.toHaveProperty('assignedResourceRoleName');
+  });
+
+  test('refuses to guess between several roles, naming them', async () => {
+    const { calls } = mockAutotask({ ...ryanRoles, '/Tickets': () => ({ itemId: 19903 }) });
+
+    const result = await handler().callTool('autotask_create_ticket', {
+      companyID: 1, title: 't', description: 'd', status: 1, priority: 2, assignedResourceID: RYAN,
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as any).text as string;
+    expect(text).toContain('Help Desk (roleID 501)');
+    expect(text).toContain('Engineer (roleID 502)');
+    expect(calls.some(c => c.method === 'POST' && c.path.endsWith('/Tickets'))).toBe(false);
+  });
+
+  test('an unassigned ticket needs no role and looks nothing up', async () => {
+    const { calls } = mockAutotask({ '/Tickets': () => ({ itemId: 19904 }) });
+
+    await handler().callTool('autotask_create_ticket', { companyID: 1, title: 't', description: 'd', status: 1, priority: 2 });
+
+    expect(posted(calls, '/Tickets')).not.toHaveProperty('assignedResourceRoleID');
+    expect(calls.some(c => c.path.endsWith('/ResourceRoles/query'))).toBe(false);
+  });
+});
+
+describe('autotask_create_time_entry roleID', () => {
+  // A fresh object per call: the handler resolves into (and deletes from) its argument.
+  const entry = (): Record<string, any> => ({ ticketID: 19879, resourceID: RYAN, dateWorked: '2026-09-10', startDateTime: '2026-09-10T09:00:00', endDateTime: '2026-09-10T10:00:00', hoursWorked: 1, summaryNotes: 'work' });
+
+  test('inherits the parent\'s role when the parent is assigned to the same resource', async () => {
+    const { calls } = mockAutotask({
+      '/Tickets/19879': () => ({ item: { id: 19879, assignedResourceID: RYAN, assignedResourceRoleID: 502 } }),
+      '/TimeEntries': () => ({ itemId: 700 }),
+    });
+
+    const result = await handler().callTool('autotask_create_time_entry', entry());
+
+    expect(result.isError).toBeFalsy();
+    expect(posted(calls, '/TimeEntries').roleID).toBe(502);
+    expect(calls.some(c => c.path.endsWith('/ResourceRoles/query'))).toBe(false);
+  });
+
+  test('an unassigned parent (null role) falls back to the resource\'s only role', async () => {
+    const { calls } = mockAutotask({
+      '/Tickets/19879': () => ({ item: { id: 19879, assignedResourceID: null, assignedResourceRoleID: null } }),
+      ...oneRole,
+      '/TimeEntries': () => ({ itemId: 701 }),
+    });
+
+    const result = await handler().callTool('autotask_create_time_entry', entry());
+
+    expect(result.isError).toBeFalsy();
+    expect(posted(calls, '/TimeEntries').roleID).toBe(501);
+  });
+
+  test('a parent assigned to someone else does not lend its role', async () => {
+    const { calls } = mockAutotask({
+      '/Tickets/19879': () => ({ item: { id: 19879, assignedResourceID: 12345, assignedResourceRoleID: 999 } }),
+      ...oneRole,
+      '/TimeEntries': () => ({ itemId: 702 }),
+    });
+
+    const result = await handler().callTool('autotask_create_time_entry', entry());
+
+    expect(result.isError).toBeFalsy();
+    expect(posted(calls, '/TimeEntries').roleID).toBe(501);
+  });
+
+  test('roleName picks among several roles and never reaches the payload', async () => {
+    const { calls } = mockAutotask({ ...ryanRoles, '/TimeEntries': () => ({ itemId: 703 }) });
+
+    const result = await handler().callTool('autotask_create_time_entry', { ...entry(), roleName: 'Help Desk' });
+
+    expect(result.isError).toBeFalsy();
+    const body = posted(calls, '/TimeEntries');
+    expect(body.roleID).toBe(501);
+    expect(body).not.toHaveProperty('roleName');
+    // The parent was not consulted: the caller said which role.
+    expect(calls.some(c => c.path.endsWith('/Tickets/19879'))).toBe(false);
+  });
+
+  test('several roles and no name is refused with the roles listed', async () => {
+    const { calls } = mockAutotask({
+      '/Tickets/19879': () => ({ item: { id: 19879, assignedResourceID: null, assignedResourceRoleID: null } }),
+      ...ryanRoles,
+      '/TimeEntries': () => ({ itemId: 704 }),
+    });
+
+    const result = await handler().callTool('autotask_create_time_entry', entry());
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('Help Desk (roleID 501)');
+    expect(calls.some(c => c.method === 'POST' && c.path.endsWith('/TimeEntries'))).toBe(false);
+  });
+
+  test('an explicit roleID is sent as given', async () => {
+    const { calls } = mockAutotask({ '/TimeEntries': () => ({ itemId: 705 }) });
+
+    await handler().callTool('autotask_create_time_entry', { ...entry(), roleID: 501 });
+
+    expect(posted(calls, '/TimeEntries').roleID).toBe(501);
+    expect(calls.some(c => c.path.endsWith('/Tickets/19879'))).toBe(false);
+  });
+});
+
+describe('compact search results keep the role ids', () => {
+  test('time entries carry roleID and tickets carry assignedResourceRoleID', () => {
+    const entries = formatCompactResponse([{ id: 1, resourceID: RYAN, roleID: 501, ticketID: 2, dateWorked: '2026-09-10', hoursWorked: 1, summaryNotes: 'x', internalNotes: 'hidden' }], 'timeEntries', {});
+    expect(entries.items[0]).toMatchObject({ roleID: 501 });
+    expect(entries.items[0]).not.toHaveProperty('internalNotes');
+
+    const tickets = formatCompactResponse([{ id: 2, ticketNumber: 'T1', title: 't', status: 1, priority: 2, companyID: 1, assignedResourceID: RYAN, assignedResourceRoleID: 501, description: 'hidden' }], 'tickets', {});
+    expect(tickets.items[0]).toMatchObject({ assignedResourceRoleID: 501 });
+    expect(tickets.items[0]).not.toHaveProperty('description');
+  });
+});

--- a/tests/resource-roles.test.ts
+++ b/tests/resource-roles.test.ts
@@ -120,6 +120,25 @@ describe('autotask_search_resource_roles', () => {
     expect(namesQuery.filter).toEqual([{ op: 'in', field: 'id', value: [501, 502] }]);
   });
 
+  test('one role held across several departments or queues is one role', async () => {
+    // Real data (Synergy, 2026-09-10): Help Desk came back five times for one
+    // resource, once per queue. Counted as assignments it would have looked
+    // like an ambiguous choice; it is a single role.
+    mockAutotask({
+      '/ResourceRoles/query': () => ({ items: [
+        { id: 1, resourceID: RYAN, roleID: 501, isActive: true, departmentID: 7 },
+        { id: 2, resourceID: RYAN, roleID: 501, isActive: true },
+        { id: 3, resourceID: RYAN, roleID: 501, isActive: true, queueID: 4 },
+      ], pageDetails: { count: 3 } }),
+      '/Roles/query': () => ({ items: [{ id: 501, name: 'Help Desk', isActive: true }], pageDetails: { count: 1 } }),
+      '/Tickets': () => ({ itemId: 19905 }),
+    });
+
+    const service = new AutotaskService(config, logger);
+    expect(await service.searchResourceRoles(RYAN)).toHaveLength(1);
+    expect(await service.resolveRoleForResource(RYAN)).toBe(501);
+  });
+
   test('resolves resourceName when no id is given', async () => {
     mockAutotask({
       '/Resources/query': () => ({ items: [{ id: RYAN, firstName: 'Ryan', lastName: 'Rampersaud', isActive: true }], pageDetails: { count: 1 } }),


### PR DESCRIPTION
## Summary

Autotask requires a `roleID` on two everyday writes — a ticket assigned to a resource (`assignedResourceRoleID`) and every ticket/task time entry — and the server currently gives a caller no way to discover one:

- no tool lists roles or a resource's role assignments (`Roles` / `ResourceRoles`);
- the compact search formatter strips `roleID` from time-entry results and `assignedResourceRoleID` from ticket results, so existing records can't be used as a reference either;
- `autotask_create_ticket` advertises `assignedResourceRoleID` but `TICKET_WRITABLE_FIELDS` doesn't include it, so the value is silently dropped even when the caller knows it (same class as #288's `dueDateTime`). Autotask then answers `When assigning a Resource, you must assign both a assignedResourceID and assignedResourceRoleID`, and the caller ends up creating the ticket unassigned;
- `autotask_create_time_entry`'s fallback to the parent's `assignedResourceRoleID` (#281) then finds nothing on that unassigned ticket, and a `null` from the API passes `=== undefined` and is sent through as `roleID: null` → `TimeEntries for Tickets must have a roleID`.

An LLM caller in that position starts guessing ids, and Autotask answers every guess with `Role does not exist or is invalid` and nothing else. We hit exactly this loop in production on 2026-09-10 (14 time entries blocked behind one unknown role id).

## Changes

- **`autotask_search_resource_roles`** (new, read-only, category `resources`): a resource's active roles with names and ids, by `resourceId` or `resourceName`. `ResourceRoles` filtered on the resource (and `isActive`) joined to `Roles` by `id in [...]` — two filtered queries, never an enumeration. De-duplicated on `roleID`: Autotask holds one `ResourceRoles` row per (resource, role, department/queue), so one role can come back several times.
- **`AutotaskService.resolveRoleForResource(resourceId, roleName?)`**: the resource's only active role, or the one whose name matches (case-insensitive exact, then substring). Anything ambiguous throws with the roles spelled out as `Name (roleID n)` so the next call can pick by name.
- **`autotask_create_ticket` / `autotask_update_ticket`**: `assignedResourceRoleID` reaches the payload; when `assignedResourceID` is set without a role it is resolved from the resource's roles, and a new `assignedResourceRoleName` picks one by name.
- **`autotask_create_time_entry`**: new `roleName`. Resolution order: `roleID` as given → `roleName` → the parent's `assignedResourceRoleID` **only when the parent is assigned to the same resource** (a `roleID` must be one of the logging resource's own roles, so a ticket assigned to a colleague contributes nothing) → the resource's roles via `resolveRoleForResource`. `assignedResourceRoleID == null` is treated as absent.
- **Compact results** keep `roleID` (time entries) and `assignedResourceRoleID` (tickets).

## Tests

- `tests/resource-roles.test.ts` (new, 16 cases): the tool's queries and join, de-duplication of repeated assignments, name resolution, ticket create with/without/by-name role, refusal on ambiguity without a POST, time-entry inheritance only from a same-resource parent, null-role fallback, explicit `roleID` untouched, formatter fields.
- `tests/create-time-entry-roleid.test.ts` updated to the new contract (parent must be assigned to the same resource; the no-role case now falls through to the resource's roles and is asserted on that error).

`tsc --noEmit` clean; 294 tests pass on our fork of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175TgkPDmeHGoagFvCqWYTy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/autotask-mcp/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791675166&installation_model_id=431408&pr_number=298&repository=WYRE-AI%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fautotask-mcp%2Fpull%2F298&signature=b11ce8782c557056cc795c857883be4ec930d7a6c3456af6e00aa92b6a378dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only tool to search a resource’s billing roles by resource ID or name.
  - Ticket assignment roles can now be selected by role name or resolved automatically when only one active role exists.
  - Time entries support role-name selection and improved automatic role resolution based on the resource and parent ticket or task.

- **Improvements**
  - Clearer errors identify missing or ambiguous resource roles.
  - Compact responses now include ticket assignment role IDs and time-entry role IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->